### PR TITLE
Fix SyntaxError-causing invalid escape sequences in docstrings

### DIFF
--- a/modules/textdetector/panel_finder.py
+++ b/modules/textdetector/panel_finder.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Finds panel order for manga page.
 >> python .\modules\textdetector\panel_finder.py <path-to-images>
 """

--- a/utils/series_context_store.py
+++ b/utils/series_context_store.py
@@ -28,7 +28,7 @@ RECENT_CONTEXT_FILENAME = "recent_context.json"
 
 
 def get_series_context_dir(series_id_or_path: str) -> str:
-    """
+    r"""
     Resolve to an absolute directory path for the series context.
     - If series_id_or_path contains a path separator (/ or \), treat as path
       (relative to PROGRAM_PATH if not absolute).


### PR DESCRIPTION
### Motivation
- Python 3.12+ treats certain backslashes in docstrings as invalid escape sequences when running forced compilation with `-W error::SyntaxWarning`, which can cause module import/compilation to fail for files that include Windows-style paths or backslashes in example text.

### Description
- Convert affected docstrings to raw string literals in `modules/textdetector/panel_finder.py` and `utils/series_context_store.py` to prevent invalid escape sequence SyntaxWarnings from being raised during compilation.

### Testing
- Ran `python -W error::SyntaxWarning -m compileall -f -q .` which completed successfully; running `python -m pytest -q` is currently blocked by an unrelated environment issue where OpenCV fails to import due to a missing system library (`libGL.so.1`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f004510570832c8b5ab2264ad60080)