### PR TITLE
Log debug details for non-critical parse_stylesheet fallbacks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@ Guidance for coding agents working in this repository.
 - Avoid eager imports of heavyweight optional dependencies unless required for execution.
 - Keep stop/pause/cancel semantics race-safe (`isRunning()`, cancel flags, resume events).
 - Do not silently swallow critical failures; log context (page/module) when continuing softly.
+- Developer note: silent fallback (`except ...: pass`) is acceptable only for non-critical UI polish paths (for example optional theme accents/icons), and should include debug-level logging with function context and exception details.
 
 ## Testing expectations
 

--- a/ui/misc.py
+++ b/ui/misc.py
@@ -6,6 +6,7 @@ from qtpy.QtGui import QPixmap,  QColor, QImage, QTextDocument, QTextCursor
 from qtpy.QtCore import Qt, QPointF
 
 from utils import shared as C
+from utils.logger import logger as LOGGER
 from utils.structures import Tuple, Union, List, Dict, Config, field, nested_dataclass
 
 
@@ -167,8 +168,12 @@ def parse_stylesheet(theme: str = '', reverse_icon: bool = False) -> str:
             if osp.isfile(bubbly_path):
                 with open(bubbly_path, 'r', encoding='utf-8') as f:
                     stylesheet += '\n' + f.read()
-    except Exception:
-        pass
+    except Exception as e:
+        LOGGER.debug(
+            "parse_stylesheet: bubbly_ui append fallback (%s: %s)",
+            type(e).__name__,
+            e,
+        )
     with open(C.THEME_PATH, 'r', encoding='utf8') as f:
         theme_dict: Dict = json.loads(f.read())
     if not theme or theme not in theme_dict:
@@ -198,8 +203,12 @@ def parse_stylesheet(theme: str = '', reverse_icon: bool = False) -> str:
                 tgt_theme['@accentColorRgba20'] = f"rgba({r}, {g}, {b}, 20%)"
                 tgt_theme['@accentColorRgba35'] = f"rgba({r}, {g}, {b}, 0.35)"
                 tgt_theme['@accentColorRgba80'] = f"rgba({r}, {g}, {b}, 0.8)"
-    except Exception:
-        pass
+    except Exception as e:
+        LOGGER.debug(
+            "parse_stylesheet: accent override fallback (%s: %s)",
+            type(e).__name__,
+            e,
+        )
 
     C.FOREGROUND_FONTCOLOR = hex2rgb(tgt_theme['@qwidgetForegroundColor'])
     C.SLIDERHANDLE_COLOR = hex2rgb(tgt_theme['@sliderHandleColor'])


### PR DESCRIPTION
### Motivation
- Capture diagnostic information for previously-silent non-critical UI fallbacks in `parse_stylesheet()` while preserving the existing UX and fallback behavior.

### Description
- Import the project logger and replace the two `except Exception: pass` blocks in `ui/misc.py::parse_stylesheet` with debug-level logs that include function context and the exception type/message, and add a developer note in `AGENTS.md` documenting that silent fallbacks are acceptable only for non-critical UI polish paths and must emit debug logging.

### Testing
- Compiled the modified files with `python -m compileall -f -q ui/misc.py AGENTS.md`, which succeeded; a runtime smoke check calling `parse_stylesheet()` was attempted but could not complete due to a missing system dependency (`libGL.so.1`) required by `cv2` in this container.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f02a33ac08832ca8b09faebc53a72a)