### PR TITLE
Refactor shared LLM provider parsing and local key bypass

### DIFF
--- a/modules/ocr/ocr_llm_api.py
+++ b/modules/ocr/ocr_llm_api.py
@@ -10,6 +10,12 @@ import openai
 import httpx
 
 from .base import register_OCR, OCRBase, TextBlock
+from utils.llm_provider import (
+    effective_provider,
+    is_local_provider,
+    normalize_model_name,
+    resolve_endpoint,
+)
 from utils.ocr_preprocess import preprocess_for_ocr
 
 
@@ -269,17 +275,8 @@ class LLM_OCR(OCRBase):
         self.current_key_index = 0
 
     def _initialize_client(self, api_key_to_use: str):
-        endpoint = self.endpoint
         provider = self._effective_provider_for_model()
-        if not endpoint:
-            if provider == "OpenAI":
-                endpoint = "https://api.openai.com/v1"
-            elif provider == "Google":
-                endpoint = "https://generativelanguage.googleapis.com/v1beta/openai"
-            elif provider == "OpenRouter":
-                endpoint = "https://openrouter.ai/api/v1"
-            elif provider == "Ollama":
-                endpoint = "http://localhost:11434/v1"
+        endpoint = resolve_endpoint(provider, self.endpoint)
 
         http_client = None
         if self.proxy:
@@ -304,19 +301,8 @@ class LLM_OCR(OCRBase):
 
     def _effective_provider_for_model(self) -> str:
         try:
-            if self.override_model:
-                return self.provider
-            m = (self.model or "").strip()
-            if ": " in m:
-                prefix = m.split(": ", 1)[0].strip().upper()
-                if prefix == "OAI":
-                    return "OpenAI"
-                if prefix == "GGL":
-                    return "Google"
-                if prefix == "OPENROUTER":
-                    return "OpenRouter"
-                if prefix == "OLL":
-                    return "Ollama"
+            return effective_provider(self.provider, self.model, self.override_model)
+        except ValueError:
             return self.provider
         except Exception:
             return self.provider
@@ -445,7 +431,7 @@ class LLM_OCR(OCRBase):
 
     def _select_api_key(self) -> Optional[str]:
         # This logic is identical to the one in LLM_API_Translator
-        if self._effective_provider_for_model() == "Ollama":
+        if is_local_provider(self._effective_provider_for_model()):
             return "local-llm"
         api_keys = self.multiple_keys_list
         single_key = self.api_key
@@ -477,7 +463,7 @@ class LLM_OCR(OCRBase):
     def ocr(self, img_base64: str, prompt_override: str = None) -> str:
         provider = self._effective_provider_for_model()
         api_key_to_use = self._select_api_key()
-        if not api_key_to_use and provider != "Ollama":
+        if not api_key_to_use and not is_local_provider(provider):
             return "[ERROR: No available API key]"
 
         # Re-initialize client if key is different from the last one used
@@ -511,9 +497,7 @@ class LLM_OCR(OCRBase):
             if self.system_prompt:
                 messages.insert(0, {"role": "system", "content": self.system_prompt})
 
-            model_name = self.override_model or self.model
-            if ": " in model_name:
-                model_name = model_name.split(": ", 1)[1]
+            model_name = normalize_model_name(self.model, self.override_model)
 
             self.logger.debug(f"OCR request with model: {model_name}")
 

--- a/modules/translators/trans_llm_api.py
+++ b/modules/translators/trans_llm_api.py
@@ -10,6 +10,12 @@ import httpx
 import openai
 from pydantic import BaseModel, Field, ValidationError
 
+from utils.llm_provider import (
+    effective_provider,
+    is_local_provider,
+    normalize_model_name,
+    resolve_endpoint,
+)
 from utils.proxy_utils import create_httpx_client
 from utils.series_context_store import (
     get_series_context_dir,
@@ -923,20 +929,7 @@ class LLM_API_Translator(BaseTranslator):
 
     def _initialize_client(self, api_key_to_use: str, provider_override: Optional[str] = None) -> bool:
         provider = provider_override or self.provider
-        endpoint = self.endpoint
-        if not endpoint:
-            if provider == "Google":
-                endpoint = "https://generativelanguage.googleapis.com/v1beta/openai"
-            elif provider == "OpenAI":
-                endpoint = "https://api.openai.com/v1"
-            elif provider == "OpenRouter":
-                endpoint = "https://openrouter.ai/api/v1"
-            elif provider == "Grok":
-                endpoint = "https://api.x.ai/v1"
-            elif provider == "LLM Studio":
-                endpoint = "http://localhost:1234/v1"
-            elif provider == "Ollama":
-                endpoint = "http://localhost:11434/v1"
+        endpoint = resolve_endpoint(provider, self.endpoint)
 
         proxy = self.proxy
         # Reuse existing client when connection config is unchanged.
@@ -992,21 +985,8 @@ class LLM_API_Translator(BaseTranslator):
         route to the implied provider to avoid sending Gemini model names to OpenAI endpoints, etc.
         """
         try:
-            if self.override_model:
-                return self.provider
-            m = (self.model or "").strip()
-            if ": " in m:
-                prefix = m.split(": ", 1)[0].strip().upper()
-                if prefix == "OAI":
-                    return "OpenAI"
-                if prefix == "GGL":
-                    return "Google"
-                if prefix == "XAI":
-                    return "Grok"
-                if prefix == "OPENROUTER":
-                    return "OpenRouter"
-                if prefix == "OLL":
-                    return "Ollama"
+            return effective_provider(self.provider, self.model, self.override_model)
+        except ValueError:
             return self.provider
         except Exception:
             return self.provider
@@ -2200,6 +2180,9 @@ class LLM_API_Translator(BaseTranslator):
         return True
 
     def _select_api_key(self) -> Optional[str]:
+        provider = self._effective_provider_for_model()
+        if is_local_provider(provider):
+            return "local-llm"
         api_keys = self.multiple_keys_list
         single_key = self.apikey
         if not api_keys and not single_key:
@@ -2214,8 +2197,6 @@ class LLM_API_Translator(BaseTranslator):
                     self.logger.warning("API key validation: %s", msg)
             except Exception:
                 pass
-
-        provider = self._effective_provider_for_model()
 
         if not api_keys:
             if self._respect_key_limit(single_key):
@@ -2568,8 +2549,8 @@ class LLM_API_Translator(BaseTranslator):
         Uses same API key/client as normal translation. Returns content string or None.
         """
         provider = self._effective_provider_for_model()
-        current_api_key = "local-llm" if provider in {"LLM Studio", "Ollama"} else self._select_api_key()
-        if not current_api_key and provider not in {"LLM Studio", "Ollama"}:
+        current_api_key = "local-llm" if is_local_provider(provider) else self._select_api_key()
+        if not current_api_key and not is_local_provider(provider):
             self.logger.warning("No API key for custom completion.")
             return None
         if not self._initialize_client(current_api_key, provider_override=provider):
@@ -2590,7 +2571,7 @@ class LLM_API_Translator(BaseTranslator):
         """Ask the model to summarize long_context to under max_chars; on failure, truncate."""
         current_api_key = "local-llm"
         provider = self._effective_provider_for_model()
-        if provider not in {"LLM Studio", "Ollama"}:
+        if not is_local_provider(provider):
             current_api_key = self._select_api_key()
             if not current_api_key:
                 self.logger.warning("No API key for context summary; truncating.")
@@ -2762,12 +2743,12 @@ class LLM_API_Translator(BaseTranslator):
     def _request_translation(self, prompt: str, expected_count: Optional[int] = None) -> Optional[TranslationResponse]:
         provider = self._effective_provider_for_model()
         current_api_key = "local-llm"
-        if provider not in {"LLM Studio", "Ollama"}:
+        if not is_local_provider(provider):
             current_api_key = self._select_api_key()
             if not current_api_key:
                 raise ConnectionError("No available API key found.")
 
-        if provider in {"LLM Studio", "Ollama"} and not self.endpoint:
+        if is_local_provider(provider) and not self.endpoint:
             if not getattr(self, "_logged_lm_studio_default_endpoint", False):
                 self._logged_lm_studio_default_endpoint = True
                 default_endpoint = "http://localhost:1234/v1" if provider == "LLM Studio" else "http://localhost:11434/v1"
@@ -2782,9 +2763,7 @@ class LLM_API_Translator(BaseTranslator):
 
         self._respect_delay()
 
-        model_name = self.override_model or self.model
-        if ": " in model_name:
-            model_name = model_name.split(": ", 1)[1]
+        model_name = normalize_model_name(self.model, self.override_model)
 
         # Section 9: remember last-used model per provider for config / UI
         try:

--- a/tests/test_llm_provider_utils.py
+++ b/tests/test_llm_provider_utils.py
@@ -1,0 +1,34 @@
+import pytest
+
+from utils.llm_provider import (
+    effective_provider,
+    is_local_provider,
+    normalize_model_name,
+    resolve_endpoint,
+)
+
+
+def test_openai_style_model_id_keeps_provider_and_normalizes_model_name():
+    provider = effective_provider("OpenAI", "OAI: gpt-4o")
+    model_name = normalize_model_name("OAI: gpt-4o")
+    assert provider == "OpenAI"
+    assert model_name == "gpt-4o"
+
+
+def test_oll_prefix_routes_to_ollama_and_bypasses_api_key():
+    provider = effective_provider("OpenAI", "OLL: qwen2.5vl:latest")
+    assert provider == "Ollama"
+    assert is_local_provider(provider)
+
+
+def test_empty_endpoint_uses_provider_default():
+    endpoint = resolve_endpoint("Ollama", "")
+    assert endpoint == "http://localhost:11434/v1"
+
+
+def test_invalid_provider_model_combinations_raise():
+    with pytest.raises(ValueError):
+        normalize_model_name("OAI:")
+
+    with pytest.raises(ValueError):
+        normalize_model_name("BADPREFIX: gpt-4o")

--- a/utils/llm_provider.py
+++ b/utils/llm_provider.py
@@ -1,0 +1,84 @@
+from typing import Optional, Tuple
+
+MODEL_PREFIX_TO_PROVIDER = {
+    "OAI": "OpenAI",
+    "GGL": "Google",
+    "XAI": "Grok",
+    "OPENROUTER": "OpenRouter",
+    "OLL": "Ollama",
+    "LLMS": "LLM Studio",
+}
+
+_PROVIDER_NORMALIZED = {v.upper(): v for v in MODEL_PREFIX_TO_PROVIDER.values()}
+PROVIDER_DEFAULT_ENDPOINTS = {
+    "OpenAI": "https://api.openai.com/v1",
+    "Google": "https://generativelanguage.googleapis.com/v1beta/openai",
+    "OpenRouter": "https://openrouter.ai/api/v1",
+    "Grok": "https://api.x.ai/v1",
+    "LLM Studio": "http://localhost:1234/v1",
+    "Ollama": "http://localhost:11434/v1",
+}
+LOCAL_PROVIDERS = {"LLM Studio", "Ollama"}
+
+
+def is_local_provider(provider: Optional[str]) -> bool:
+    return (provider or "") in LOCAL_PROVIDERS
+
+
+def default_endpoint_for_provider(provider: Optional[str]) -> Optional[str]:
+    return PROVIDER_DEFAULT_ENDPOINTS.get(provider or "")
+
+
+def resolve_endpoint(provider: Optional[str], endpoint: Optional[str]) -> Optional[str]:
+    normalized = (endpoint or "").strip()
+    if normalized:
+        return normalized
+    return default_endpoint_for_provider(provider)
+
+
+def parse_provider_prefixed_model(model_id: Optional[str]) -> Tuple[Optional[str], str]:
+    """Return (provider_from_prefix, bare_model_id).
+
+    Accepts forms like "OAI: gpt-4o" and "OpenRouter: model/id".
+    Raises ValueError for malformed/unknown prefixed identifiers.
+    """
+    model_text = (model_id or "").strip()
+    if not model_text:
+        return None, ""
+
+    if ":" not in model_text:
+        return None, model_text
+
+    prefix, bare_model = model_text.split(":", 1)
+    prefix = prefix.strip()
+    bare_model = bare_model.strip()
+    if not prefix or not bare_model:
+        raise ValueError(f"Invalid provider/model id combination: '{model_text}'")
+
+    mapped_provider = MODEL_PREFIX_TO_PROVIDER.get(prefix.upper())
+    if mapped_provider:
+        return mapped_provider, bare_model
+
+    normalized_provider = _PROVIDER_NORMALIZED.get(prefix.upper())
+    if normalized_provider:
+        return normalized_provider, bare_model
+
+    raise ValueError(f"Unknown provider prefix '{prefix}' in '{model_text}'")
+
+
+def effective_provider(
+    selected_provider: Optional[str],
+    model_id: Optional[str],
+    override_model: Optional[str] = None,
+) -> str:
+    if (override_model or "").strip():
+        return selected_provider or ""
+    parsed_provider, _ = parse_provider_prefixed_model(model_id)
+    return parsed_provider or (selected_provider or "")
+
+
+def normalize_model_name(model_id: Optional[str], override_model: Optional[str] = None) -> str:
+    if (override_model or "").strip():
+        return override_model.strip()
+    _provider, bare_model = parse_provider_prefixed_model(model_id)
+    return bare_model


### PR DESCRIPTION
### Motivation
- Remove duplicated provider/model parsing and endpoint fallback logic present in OCR and translator LLM modules by centralizing it to a single helper.
- Make local-provider detection and API-key bypass semantics consistent across OCR and translation flows (e.g., `OLL:` -> Ollama, LM Studio defaults).
- Provide clearer errors for malformed provider-prefixed model identifiers.

### Description
- Added `utils/llm_provider.py` implementing provider-prefix parsing, `effective_provider`, `normalize_model_name`, `resolve_endpoint`, and `is_local_provider`, with known defaults and local provider list.
- Refactored `modules/ocr/ocr_llm_api.py` to use the shared helpers for effective provider resolution, model-name normalization, endpoint fallback, and local-provider API-key bypass.
- Refactored `modules/translators/trans_llm_api.py` to use the same helpers for provider/model parsing, endpoint resolution, model normalization, and to centralize local-provider key bypass in `_select_api_key` and request flows.
- Parsing now raises `ValueError` for malformed or unknown prefixed model identifiers to surface invalid combinations.

### Testing
- Compiled changed files with `python -m compileall -f -q modules/ocr/ocr_llm_api.py modules/translators/trans_llm_api.py utils/llm_provider.py tests/test_llm_provider_utils.py` and compilation succeeded.
- Ran unit tests with `pytest -q tests/test_llm_provider_utils.py` and observed `4 passed` (all tests succeeded).
- The included tests cover OpenAI-style prefix parsing, `OLL:` prefix routing to Ollama and local detection, empty endpoint fallback to provider defaults, and invalid prefixed IDs raising `ValueError`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f02a2eb080832c90f85bda7a9f8ed3)