### PR TITLE
Add structured, rate-limited soft-fail warnings for HF and Paddle detectors

### DIFF
--- a/modules/textdetector/detector_hf_object_detection.py
+++ b/modules/textdetector/detector_hf_object_detection.py
@@ -6,6 +6,7 @@ or a YOLO .pt as primary (no HF). Use model_id: HF id (e.g. ogkalu/...) or path 
 """
 import copy
 import os.path as osp
+import time
 import numpy as np
 import cv2
 from typing import Tuple, List
@@ -324,6 +325,26 @@ if _HF_DET_AVAILABLE:
             self._conjoined_yolo_path = None
             self._conjoined_yolo_paths: List[str] = []
             self._conjoined_device = None
+            self._warning_state = {}
+
+        def _warn_soft_fail(self, stage: str, error: Exception = None, proj=None, model_ref: str = None):
+            page_id = getattr(proj, "current_img", None) if proj is not None else None
+            model_value = model_ref or (self.params.get("model_id") or {}).get("value", self._model_id)
+            err_text = f"{type(error).__name__}: {error}" if error is not None else "unknown"
+            key = ("hf_object_det", stage, str(model_value), str(page_id), err_text)
+            now = time.monotonic()
+            last_ts = self._warning_state.get(key, 0.0)
+            if now - last_ts < 60:
+                return
+            self._warning_state[key] = now
+            self.logger.warning(
+                "detector_soft_fail detector=%s stage=%s model=%s page=%s error=%s",
+                "hf_object_det",
+                stage,
+                model_value or "unknown",
+                page_id or "unknown",
+                err_text,
+            )
 
         @staticmethod
         def _parse_multiline_paths(s) -> List[str]:
@@ -821,7 +842,7 @@ if _HF_DET_AVAILABLE:
                     pil_img = PILImage.fromarray(det_img)
                     results = pipe_to_use(pil_img)
                 except Exception as e:
-                    self.logger.warning(f"HF object-detection failed: {e}")
+                    self._warn_soft_fail(stage="primary_hf_predict", error=e, proj=proj)
                     return out
                 if not results:
                     return out
@@ -1029,9 +1050,9 @@ if _HF_DET_AVAILABLE:
                                 if not overlap:
                                     blk_list.append(o)
                                     existing.append(o)
-            except Exception:
+            except Exception as e:
                 # Never fail detection due to optional secondary pass
-                pass
+                self._warn_soft_fail(stage="conjoined_secondary_merge", error=e, proj=proj)
             inset_ratio = 0.0
             bi = self.params.get("box_inset_ratio", {})
             if isinstance(bi, dict):

--- a/modules/textdetector/detector_paddle_det.py
+++ b/modules/textdetector/detector_paddle_det.py
@@ -9,6 +9,7 @@ import sys
 import json
 import tempfile
 import subprocess
+import time
 import numpy as np
 import cv2
 from typing import Tuple, List
@@ -210,6 +211,26 @@ if _PADDLE_AVAILABLE:
             super().__init__(**params)
             self.model = None
             self._use_subprocess = False  # True when torch already loaded to avoid paddle/torch CUDA type conflict
+            self._warning_state = {}
+
+        def _warn_soft_fail(self, stage: str, error: Exception = None, proj: ProjImgTrans = None):
+            page_id = getattr(proj, "current_img", None) if proj is not None else None
+            model_ref = "PaddleOCR-det"
+            err_text = f"{type(error).__name__}: {error}" if error is not None else "unknown"
+            key = ("paddle_det", stage, model_ref, str(page_id), err_text)
+            now = time.monotonic()
+            last_ts = self._warning_state.get(key, 0.0)
+            if now - last_ts < 60:
+                return
+            self._warning_state[key] = now
+            self.logger.warning(
+                "detector_soft_fail detector=%s stage=%s model=%s page=%s error=%s",
+                "paddle_det",
+                stage,
+                model_ref,
+                page_id or "unknown",
+                err_text,
+            )
 
         def _load_model(self):
             if self.model is not None:
@@ -237,6 +258,7 @@ if _PADDLE_AVAILABLE:
                     self._use_subprocess = True
                     self.model = True
                     return
+                self._warn_soft_fail(stage="load_model", error=e, proj=None)
                 raise
 
         def _detect(self, img: np.ndarray, proj: ProjImgTrans = None) -> Tuple[np.ndarray, List[TextBlock]]:
@@ -282,11 +304,19 @@ if _PADDLE_AVAILABLE:
                             env={**os.environ, "FLAGS_use_mkldnn": "0", "PADDLE_PDX_DISABLE_MODEL_SOURCE_CHECK": "1"},
                         )
                         if result.returncode != 0:
-                            self.logger.error(f"Paddle det subprocess failed: {result.stderr or result.stdout}")
+                            self._warn_soft_fail(
+                                stage="subprocess_run",
+                                error=RuntimeError(result.stderr or result.stdout or "non-zero return"),
+                                proj=proj,
+                            )
                             return mask, blk_list
                         out = json.loads(result.stdout)
                         if "error" in out:
-                            self.logger.error(out["error"])
+                            self._warn_soft_fail(
+                                stage="subprocess_output",
+                                error=RuntimeError(out["error"]),
+                                proj=proj,
+                            )
                             return mask, blk_list
                         strict = self.params.get("strict_bubble_mode", {}).get("value", True)
                         min_area = 200
@@ -320,7 +350,7 @@ if _PADDLE_AVAILABLE:
                                 pts = np.array(line_pts, dtype=np.int32)
                                 cv2.fillPoly(mask, [pts], 255)
                 except (subprocess.TimeoutExpired, json.JSONDecodeError, KeyError) as e:
-                    self.logger.error(f"Paddle det subprocess error: {e}")
+                    self._warn_soft_fail(stage="subprocess_parse", error=e, proj=proj)
                     return mask, blk_list
                 if not blk_list:
                     return mask, blk_list
@@ -398,7 +428,7 @@ if _PADDLE_AVAILABLE:
                     text_det_box_thresh=box_thresh,
                 )
             except Exception as e:
-                self.logger.error(f"Paddle det failed: {e}")
+                self._warn_soft_fail(stage="predict", error=e, proj=proj)
                 return mask, blk_list
 
             if not result or len(result) == 0:

--- a/modules/textdetector/detector_paddle_v5.py
+++ b/modules/textdetector/detector_paddle_v5.py
@@ -6,6 +6,8 @@ Requires: paddleocr (3.x for PP-OCRv5), paddlepaddle.
 """
 import os
 import tempfile
+import time
+import logging
 import numpy as np
 import cv2
 from typing import Tuple, List
@@ -25,6 +27,33 @@ os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
 # Disable oneDNN/MKLDNN to avoid "ConvertPirAttribute2RuntimeAttribute not support" with PP-OCRv5_server_det on some Paddle versions
 os.environ["FLAGS_use_mkldnn"] = "0"
 os.environ["FLAGS_use_mkldnn_in_fc"] = "0"
+_MODULE_LOGGER = logging.getLogger("BallonTranslator")
+_WARNING_STATE = {}
+
+
+def _warn_rate_limited(
+    detector_name: str,
+    stage: str,
+    model_ref: str,
+    page_id: str,
+    error: Exception = None,
+    interval_seconds: int = 60,
+) -> None:
+    err_text = f"{type(error).__name__}: {error}" if error is not None else "unknown"
+    key = (detector_name, stage, str(model_ref), str(page_id), err_text)
+    now = time.monotonic()
+    last_ts = _WARNING_STATE.get(key, 0.0)
+    if now - last_ts < interval_seconds:
+        return
+    _WARNING_STATE[key] = now
+    _MODULE_LOGGER.warning(
+        "detector_soft_fail detector=%s stage=%s model=%s page=%s error=%s",
+        detector_name,
+        stage,
+        model_ref or "unknown",
+        page_id or "unknown",
+        err_text,
+    )
 
 
 def _bbox_distance_px(blk_a: TextBlock, blk_b: TextBlock) -> float:
@@ -120,7 +149,14 @@ def _split_block_by_image_gap(
             new_blk._detected_font_size = max(bottom_im - top_im, 12)
             out.append(new_blk)
         return out if len(out) >= 2 else [blk]
-    except Exception:
+    except Exception as e:
+        _warn_rate_limited(
+            detector_name="paddle_det_v5",
+            stage="split_cross_bubble_lines",
+            model_ref="PP-OCRv5",
+            page_id="unknown",
+            error=e,
+        )
         return [blk]
 
 
@@ -211,6 +247,26 @@ if _PADDLE_V5_AVAILABLE:
             self.model = None
             self._model_name = None
             self._device = None
+            self._warning_state = {}
+
+        def _warn_soft_fail(self, stage: str, error: Exception = None, proj: ProjImgTrans = None):
+            page_id = getattr(proj, "current_img", None) if proj is not None else None
+            model_ref = self._model_name or (self.params.get("model_name") or {}).get("value", "PP-OCRv5_mobile_det")
+            err_text = f"{type(error).__name__}: {error}" if error is not None else "unknown"
+            key = ("paddle_det_v5", stage, str(model_ref), str(page_id), err_text)
+            now = time.monotonic()
+            last_ts = self._warning_state.get(key, 0.0)
+            if now - last_ts < 60:
+                return
+            self._warning_state[key] = now
+            self.logger.warning(
+                "detector_soft_fail detector=%s stage=%s model=%s page=%s error=%s",
+                "paddle_det_v5",
+                stage,
+                model_ref,
+                page_id or "unknown",
+                err_text,
+            )
 
         def _load_model(self):
             model_name = (self.params.get("model_name") or {}).get("value", "PP-OCRv5_mobile_det") or "PP-OCRv5_mobile_det"
@@ -224,8 +280,8 @@ if _PADDLE_V5_AVAILABLE:
                 try:
                     import paddle
                     paddle.set_flags({"FLAGS_use_mkldnn": False})
-                except Exception:
-                    pass
+                except Exception as e:
+                    self._warn_soft_fail(stage="set_paddle_flags", error=e, proj=None)
                 self.model = TextDetection(model_name=model_name, device=device)
             except ImportError as e:
                 if "already registered" in str(e) or "_gpuDeviceProperties" in str(e):
@@ -275,7 +331,7 @@ if _PADDLE_V5_AVAILABLE:
                 output = list(output) if output is not None else []
             except Exception as e:
                 err_msg = str(e)
-                self.logger.error(f"Paddle v5 det failed: {e}")
+                self._warn_soft_fail(stage="predict", error=e, proj=proj)
                 if "ConvertPirAttribute2RuntimeAttribute" in err_msg or "onednn_instruction" in err_msg:
                     self.logger.warning(
                         "PP-OCRv5 hit Paddle/oneDNN bug (both mobile and server). Fix: pip install paddlepaddle==3.2.0 paddleocr==3.3.0 then restart. See PaddleOCR discussion #17350."
@@ -285,8 +341,8 @@ if _PADDLE_V5_AVAILABLE:
                 if tmp_path and os.path.exists(tmp_path):
                     try:
                         os.unlink(tmp_path)
-                    except OSError:
-                        pass
+                    except OSError as e:
+                        self._warn_soft_fail(stage="cleanup_temp_file", error=e, proj=proj)
             if not output:
                 return mask, blk_list
             for item in output:

--- a/scripts/check_detector_exception_logging.py
+++ b/scripts/check_detector_exception_logging.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Lint-style check: critical detector exception handlers should log before soft-failing."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+TARGETS = {
+    "modules/textdetector/detector_hf_object_detection.py": {"_detect", "run_on_image", "_load_model"},
+    "modules/textdetector/detector_paddle_det.py": {"_detect", "_load_model"},
+    "modules/textdetector/detector_paddle_v5.py": {"_detect", "_load_model", "_split_block_by_image_gap"},
+}
+
+
+class Checker(ast.NodeVisitor):
+    def __init__(self, target_functions: set[str]) -> None:
+        self.target_functions = target_functions
+        self.fn_stack: list[str] = []
+        self.violations: list[str] = []
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self.fn_stack.append(node.name)
+        self.generic_visit(node)
+        self.fn_stack.pop()
+
+    def _current_function(self) -> str | None:
+        return self.fn_stack[-1] if self.fn_stack else None
+
+    def visit_ExceptHandler(self, node: ast.ExceptHandler) -> None:
+        fn = self._current_function()
+        if fn in self.target_functions and _is_broad_exception(node.type):
+            if not _contains_logger_call(node.body):
+                self.violations.append(
+                    f"{fn}: broad except at line {node.lineno} has no logger warning/error call"
+                )
+        self.generic_visit(node)
+
+
+def _is_broad_exception(exc: ast.expr | None) -> bool:
+    if exc is None:
+        return True
+    if isinstance(exc, ast.Name) and exc.id == "Exception":
+        return True
+    return False
+
+
+def _contains_logger_call(nodes: list[ast.stmt]) -> bool:
+    for n in ast.walk(ast.Module(body=nodes, type_ignores=[])):
+        if not isinstance(n, ast.Call):
+            continue
+        func = n.func
+        if isinstance(func, ast.Attribute) and func.attr in {"_warn_soft_fail", "_warn_rate_limited"}:
+            return True
+        if isinstance(func, ast.Name) and func.id in {"_warn_rate_limited"}:
+            return True
+        if not isinstance(func, ast.Attribute):
+            continue
+        if func.attr not in {"warning", "error", "exception"}:
+            continue
+        base = func.value
+        if isinstance(base, ast.Attribute) and base.attr == "logger":
+            return True
+        if isinstance(base, ast.Name) and "logger" in base.id.lower():
+            return True
+    return False
+
+
+def main() -> int:
+    all_violations: list[str] = []
+    for rel_path, functions in TARGETS.items():
+        src_path = ROOT / rel_path
+        tree = ast.parse(src_path.read_text(encoding="utf-8"), filename=rel_path)
+        checker = Checker(functions)
+        checker.visit(tree)
+        for v in checker.violations:
+            all_violations.append(f"{rel_path}: {v}")
+
+    if all_violations:
+        print("Detector exception logging check failed:")
+        for v in all_violations:
+            print(f"- {v}")
+        return 1
+
+    print("Detector exception logging check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- Reduce silent failures in text detectors by emitting structured warnings with context (detector, stage, model, page, error) while preserving soft-fail behavior.
- Avoid log flooding from repeated identical failures by adding simple dedup/rate-limit for identical warning keys.
- Provide a lightweight lint check to ensure broad exception handlers in critical detector flows call a logger or the new helper.

### Description
- Added structured, rate-limited soft-fail helpers and warning state to `HFObjectDetector` in `modules/textdetector/detector_hf_object_detection.py`, and replaced a couple of previously-silent `except`/`pass` branches with calls to `_warn_soft_fail` that include detector name, stage, model id/path and page id when available.
- Added `_warn_soft_fail` helper and wired structured warnings into model load / subprocess / predict / secondary-pass branches for `modules/textdetector/detector_paddle_det.py` so failures now warn (soft-fail) instead of silently passing.
- Added module-level `_warn_rate_limited` and per-instance `_warn_soft_fail` logic in `modules/textdetector/detector_paddle_v5.py`, replaced silent `except`/`pass` locations (including split/cleanup/model flag handling) with structured, rate-limited warnings.
- Introduced a compact AST-based lint script `scripts/check_detector_exception_logging.py` that ensures broad `except` handlers in targeted detector functions emit a `logger` call or call the new helper wrappers.

### Testing
- Ran compilation on changed files with `python -m compileall -f -q modules/textdetector/detector_hf_object_detection.py modules/textdetector/detector_paddle_det.py modules/textdetector/detector_paddle_v5.py scripts/check_detector_exception_logging.py` and it completed successfully.
- Executed the new lint-style check with `python scripts/check_detector_exception_logging.py` and it passed (no violations).
- Attempted a dynamic import smoke-check of the modified detector modules, but importing the package failed due to the environment missing `libGL.so.1` required by `cv2`, so the runtime import smoke test could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f02a2b7b24832cb54623ceac6751d9)