### PR TITLE
Add detect-only post-detect auto-fit flow with font-size override guard

### DIFF
--- a/tests/test_detect_finished_layout_flags.py
+++ b/tests/test_detect_finished_layout_flags.py
@@ -1,0 +1,21 @@
+from utils.detect_layout_flags import (
+    is_detect_only_run,
+    should_enable_auto_textlayout,
+    should_run_post_detect_autofit,
+)
+
+
+def test_detect_only_autolayout_flag_enabled_with_program_font_size():
+    assert should_enable_auto_textlayout(True, 0, True, False, False) is True
+    assert is_detect_only_run(True, False, False) is True
+    assert should_run_post_detect_autofit(True, 0, True, False, False) is True
+
+
+def test_detect_only_post_autofit_disabled_for_manual_font_size_override():
+    assert should_enable_auto_textlayout(True, 1, True, False, False) is False
+    assert should_run_post_detect_autofit(True, 1, True, False, False) is False
+
+
+def test_post_detect_autofit_only_for_detect_only_pipeline():
+    assert should_run_post_detect_autofit(True, 0, True, True, False) is False
+    assert should_run_post_detect_autofit(True, 0, False, True, True) is False

--- a/ui/mainwindow.py
+++ b/ui/mainwindow.py
@@ -17,6 +17,7 @@ from qtpy.QtGui import QContextMenuEvent, QTextCursor, QGuiApplication, QIcon, Q
 
 from utils.logger import logger as LOGGER
 from utils.text_processing import is_cjk, full_len, half_len
+from utils.detect_layout_flags import should_enable_auto_textlayout, should_run_post_detect_autofit
 from utils.text_layout import _merge_stub_lines_in_string
 from utils.textblock import TextBlock, TextAlignment, examine_textblk
 from utils.split_text_region import split_textblock
@@ -2819,6 +2820,7 @@ class MainWindow(mainwindow_cls):
 
     def on_pagtrans_finished(self, page_index: int):
         blk_list = self.imgtrans_proj.get_blklist_byidx(page_index)
+        detected_block_indices = [ii for ii, blk in enumerate(blk_list) if getattr(blk, 'font_size', -1) < 0]
         ffmt_list = None
         if len(self.backup_blkstyles) == self.imgtrans_proj.num_pages and len(self.backup_blkstyles[page_index]) == len(blk_list):
             ffmt_list: List[FontFormat] = self.backup_blkstyles[page_index]
@@ -2884,10 +2886,12 @@ class MainWindow(mainwindow_cls):
                     if sw > 0 and pcfg.module.enable_ocr and pcfg.module.enable_detect and not override_fnt_size:
                         blk.font_size = blk.font_size / (1 + sw)
 
-            self.st_manager.auto_textlayout_flag = (
-                pcfg.let_autolayout_flag
-                and (pcfg.let_fntsize_flag == 0)
-                and (pcfg.module.enable_detect or pcfg.module.enable_ocr or pcfg.module.enable_translate)
+            self.st_manager.auto_textlayout_flag = should_enable_auto_textlayout(
+                pcfg.let_autolayout_flag,
+                pcfg.let_fntsize_flag,
+                pcfg.module.enable_detect,
+                pcfg.module.enable_ocr,
+                pcfg.module.enable_translate,
             )
         else:
             self.st_manager.auto_textlayout_flag = False
@@ -2902,6 +2906,14 @@ class MainWindow(mainwindow_cls):
         # Run auto layout (and balloon shape Auto) on all blocks so text boxes match bubble shape after Run.
         if self.st_manager.auto_textlayout_flag:
             self.st_manager.run_auto_layout_on_current_page_once()
+            if should_run_post_detect_autofit(
+                pcfg.let_autolayout_flag,
+                pcfg.let_fntsize_flag,
+                pcfg.module.enable_detect,
+                pcfg.module.enable_ocr,
+                pcfg.module.enable_translate,
+            ):
+                self.st_manager.run_detect_post_autofit_on_current_page_once(detected_block_indices)
 
         if not pcfg.module.enable_detect and pcfg.module.enable_translate:
             # Skip squeeze when auto layout ran; layout_textblk already set box size and squeeze would narrow/stretch boxes

--- a/ui/scenetext_manager.py
+++ b/ui/scenetext_manager.py
@@ -1142,6 +1142,33 @@ class SceneTextManager(QObject):
             pcfg.let_autolayout_flag = old_autolayout
             self.auto_textlayout_flag = old_flag
 
+    def run_detect_post_autofit_on_current_page_once(self, block_indices: List[int]):
+        """Apply the same auto-fit routine as shortcut Format→Auto fit to selected detected blocks."""
+        from utils.config import pcfg
+        if not block_indices:
+            return
+        selected_blks = []
+        for idx in block_indices:
+            if 0 <= idx < len(self.textblk_item_list):
+                blkitem = self.textblk_item_list[idx]
+                if not getattr(blkitem.fontformat, 'vertical', False):
+                    selected_blks.append(blkitem)
+        if not selected_blks:
+            return
+        old_autolayout = getattr(pcfg, 'let_autolayout_flag', True)
+        old_flag = self.auto_textlayout_flag
+        try:
+            pcfg.let_autolayout_flag = True
+            self.auto_textlayout_flag = True
+            for blkitem in selected_blks:
+                self.layout_textblk(blkitem)
+                self.layout_textblk(blkitem)
+                self._scale_font_to_fit_box(blkitem)
+            self.canvas.setProjSaveState(True)
+        finally:
+            pcfg.let_autolayout_flag = old_autolayout
+            self.auto_textlayout_flag = old_flag
+
     def onAutoLayoutTextblks(self):
         selected_blks = self.canvas.selected_text_items()
         old_html_lst, old_rect_lst, trans_widget_lst = [], [], []
@@ -2665,4 +2692,3 @@ def get_text_size(fm: QFontMetricsF, text: str) -> Tuple[int, int]:
     
 def get_words_length_list(fm: QFontMetricsF, words: List[str]) -> List[int]:
     return [int(np.ceil(fm.horizontalAdvance(word))) for word in words]
-

--- a/utils/detect_layout_flags.py
+++ b/utils/detect_layout_flags.py
@@ -1,0 +1,20 @@
+def should_enable_auto_textlayout(let_autolayout_flag: bool, let_fntsize_flag: int, enable_detect: bool, enable_ocr: bool, enable_translate: bool) -> bool:
+    return (
+        bool(let_autolayout_flag)
+        and (int(let_fntsize_flag) == 0)
+        and (bool(enable_detect) or bool(enable_ocr) or bool(enable_translate))
+    )
+
+
+def is_detect_only_run(enable_detect: bool, enable_ocr: bool, enable_translate: bool) -> bool:
+    return bool(enable_detect) and (not bool(enable_ocr)) and (not bool(enable_translate))
+
+
+def should_run_post_detect_autofit(let_autolayout_flag: bool, let_fntsize_flag: int, enable_detect: bool, enable_ocr: bool, enable_translate: bool) -> bool:
+    return should_enable_auto_textlayout(
+        let_autolayout_flag,
+        let_fntsize_flag,
+        enable_detect,
+        enable_ocr,
+        enable_translate,
+    ) and is_detect_only_run(enable_detect, enable_ocr, enable_translate)


### PR DESCRIPTION
### Motivation
- Make detect-only runs apply the same auto-fit/layout routine used by the Format → Auto fit action so newly detected blocks are laid out and font-scaled when the auto-layout config is enabled. 
- Preserve explicit user font-size choices by ensuring manual font-size override (`let_fntsize_flag == 1`) prevents automatic re-fitting.
- Expose and test the gating logic for when auto-layout / post-detect auto-fit should run so behavior is explicit and unit-testable.

### Description
- Centralized the enablement logic into a new helper module `utils/detect_layout_flags.py` exposing `should_enable_auto_textlayout`, `is_detect_only_run`, and `should_run_post_detect_autofit` so the conditions are reusable and testable.
- In `ui/mainwindow.py` `on_pagtrans_finished` now captures indices of newly-detected blocks and uses `should_enable_auto_textlayout` to set `self.st_manager.auto_textlayout_flag` instead of inlining the condition.
- After the page auto-layout pass, `on_pagtrans_finished` calls a new `SceneTextManager.run_detect_post_autofit_on_current_page_once(...)` for detect-only pipelines when `should_run_post_detect_autofit` is true, applying the same routine used by the Format → Auto fit shortcut (two layout passes + scale-to-fit) only for the newly detected blocks.
- Implemented `SceneTextManager.run_detect_post_autofit_on_current_page_once(...)` in `ui/scenetext_manager.py` which mirrors the auto-fit flow while temporarily enabling auto-layout flags and preserving/restoring previous flags.
- Added a small non-GUI regression test `tests/test_detect_finished_layout_flags.py` that validates the gating logic for detect-only mode and the manual font-size override case.
- The change avoids overriding manual formatting by gating both auto-layout and post-detect auto-fit with the shared helpers that check `let_fntsize_flag`.
- Manual verification (quick): change font on selected block → run auto-fit action → run detect pipeline → confirm expected font re-fit behavior.

### Testing
- Ran `python -m compileall -f -q ui/mainwindow.py ui/scenetext_manager.py utils/detect_layout_flags.py tests/test_detect_finished_layout_flags.py` which completed successfully.
- Ran `pytest -q tests/test_detect_finished_layout_flags.py` and observed `3 passed`.
- The regression tests exercise the new pure-Python gating logic to avoid importing heavy GUI/native deps during collection, and the final test run succeeded (3 tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f02a26593c832cbe45ed6d1d5268a5)