### PR TITLE
Add temporary diagnostic-mode logging for UI actions and pipeline transitions

### DIFF
--- a/docs/ISSUE_13_REPRO_TEMPLATE_COMMENT.md
+++ b/docs/ISSUE_13_REPRO_TEMPLATE_COMMENT.md
@@ -1,0 +1,8 @@
+<!-- Maintainer template comment for Issue #13 -->
+Thanks for reporting this. To help us reproduce and fix it quickly, please share:
+
+1. **Repro steps** (exact clicks/shortcuts, page(s), and model selections).
+2. **Expected behavior** vs **actual behavior**.
+3. Which flow fails for you: **detect**, **OCR**, **translate**, or **manual edit** (undo/redo/delete/recover).
+4. Whether it happens every time, and if yes, from a fresh app restart/project.
+5. Optional but helpful: diagnostic logs with temporary `diagnostic_mode=true` in config.

--- a/ui/mainwindow.py
+++ b/ui/mainwindow.py
@@ -27,7 +27,7 @@ from modules.translators.base import lang_display_to_key
 from modules import GET_VALID_TEXTDETECTORS, GET_VALID_INPAINTERS, GET_VALID_TRANSLATORS, GET_VALID_OCR
 from .misc import parse_stylesheet, set_html_family, QKEY, pixmap2ndarray
 from .custom_widget.animated_stack import AnimatedStackWidget
-from utils.config import ProgramConfig, pcfg, save_config, text_styles, save_text_styles, load_textstyle_from, FontFormat
+from utils.config import ProgramConfig, pcfg, save_config, text_styles, save_text_styles, load_textstyle_from, FontFormat, log_diagnostic_event
 from utils.shortcuts import get_shortcut
 from utils.proj_imgtrans import ProjImgTrans
 from utils.zip_batch import ZipBatchManager
@@ -1644,9 +1644,21 @@ class MainWindow(mainwindow_cls):
             self.canvas.resize_to_fit_content_signal.emit()
 
     def on_redo(self):
+        log_diagnostic_event(
+            "ui.redo",
+            page_index=self.pageList.currentRow(),
+            page_name=getattr(self.imgtrans_proj, 'current_img', None) if self.imgtrans_proj is not None else None,
+            block_count=len(getattr(self.st_manager, 'textblk_item_list', [])) if self.st_manager is not None else 0,
+        )
         self.canvas.redo()
 
     def on_undo(self):
+        log_diagnostic_event(
+            "ui.undo",
+            page_index=self.pageList.currentRow(),
+            page_name=getattr(self.imgtrans_proj, 'current_img', None) if self.imgtrans_proj is not None else None,
+            block_count=len(getattr(self.st_manager, 'textblk_item_list', [])) if self.st_manager is not None else 0,
+        )
         self.canvas.undo()
 
     def on_page_search(self):

--- a/ui/module_manager.py
+++ b/ui/module_manager.py
@@ -35,7 +35,7 @@ from utils.series_context_store import DEFAULT_SERIES_ID, get_series_context_dir
 from .custom_widget import ImgtransProgressMessageBox, ParamComboBox
 from .configpanel import ConfigPanel
 from utils.proj_imgtrans import ProjImgTrans
-from utils.config import pcfg, RunStatus
+from utils.config import pcfg, RunStatus, log_diagnostic_event
 from utils.image_upscale import (
     apply_initial_upscale,
     downscale_to_size,
@@ -920,6 +920,12 @@ class ImgtransThread(QThread):
             if self.stop_requested or (getattr(self, 'cancel_flag', None) is not None and self.cancel_flag.is_set()):
                 break
             LOGGER.info(f'Page {page_num}/{len(pages_to_iterate)} ({imgname}): starting')
+            log_diagnostic_event(
+                "pipeline.page_start",
+                page_index=page_num - 1,
+                page_name=imgname,
+                total_pages=len(pages_to_iterate),
+            )
             if cfg_module.enable_ocr and hasattr(self.ocr, 'restore_to_device'):
                 try:
                     self.ocr.restore_to_device()
@@ -941,6 +947,12 @@ class ImgtransThread(QThread):
             need_save_mask = False
             blk_removed: List[TextBlock] = []
             if cfg_module.enable_detect:
+                log_diagnostic_event(
+                    "pipeline.detect_start",
+                    page_index=page_num - 1,
+                    page_name=imgname,
+                    block_count=len(blk_list) if blk_list is not None else len(self.imgtrans_proj.pages.get(imgname, []) or []),
+                )
                 if self.textdetector is None:
                     create_error_dialog(
                         RuntimeError("Text detector module is not set or failed to load."),
@@ -1089,6 +1101,12 @@ class ImgtransThread(QThread):
                 self.imgtrans_proj.update_page_progress(imgname, RunStatus.FIN_DET)
                 self.update_detect_progress.emit(self.detect_counter)
                 LOGGER.info(f'Page {page_num}/{len(pages_to_iterate)}: detection done')
+                log_diagnostic_event(
+                    "pipeline.detect_finish",
+                    page_index=page_num - 1,
+                    page_name=imgname,
+                    block_count=len(blk_list) if blk_list is not None else 0,
+                )
 
             # Replace translation mode: load translated image, detect+OCR on it, match blocks, set raw blk.translation (manga-translator-ui style)
             if (getattr(cfg_module, "replace_translation_mode", False) and
@@ -1157,6 +1175,12 @@ class ImgtransThread(QThread):
 
             if cfg_module.enable_ocr:
                 LOGGER.info(f'Page {page_num}/{len(pages_to_iterate)}: OCR running')
+                log_diagnostic_event(
+                    "pipeline.ocr_start",
+                    page_index=page_num - 1,
+                    page_name=imgname,
+                    block_count=len(blk_list) if blk_list is not None else 0,
+                )
                 ocr_runner = getattr(self, '_auto_ocr_instance', None) if getattr(cfg_module, 'ocr_auto_by_language', False) else None
                 if ocr_runner is None:
                     ocr_runner = self.ocr
@@ -1302,6 +1326,12 @@ class ImgtransThread(QThread):
                 self.imgtrans_proj.update_page_progress(imgname, RunStatus.FIN_OCR)
                 self.update_ocr_progress.emit(self.ocr_counter)
                 LOGGER.info(f'Page {page_num}/{len(pages_to_iterate)}: OCR done')
+                log_diagnostic_event(
+                    "pipeline.ocr_finish",
+                    page_index=page_num - 1,
+                    page_name=imgname,
+                    block_count=len(blk_list) if blk_list is not None else 0,
+                )
                 if cfg_module.enable_inpaint and getattr(self.ocr, 'device', None) in GPUINTENSIVE_SET and hasattr(self.ocr, 'offload_to_cpu'):
                     self.ocr.offload_to_cpu()
                     soft_empty_cache()
@@ -1312,17 +1342,41 @@ class ImgtransThread(QThread):
                 need_save_mask = False
 
             if cfg_module.enable_translate:
+                log_diagnostic_event(
+                    "pipeline.translate_start",
+                    page_index=page_num - 1,
+                    page_name=imgname,
+                    block_count=len(blk_list) if blk_list is not None else 0,
+                )
                 # Skip translator stage for one-step VLM flow (already wrote blk.translation).
                 if getattr(cfg_module, "translation_mode", "two_step") == "one_step_vlm":
                     self.translate_counter += 1
                     self.update_translate_progress.emit(self.translate_counter)
+                    log_diagnostic_event(
+                        "pipeline.translate_finish",
+                        page_index=page_num - 1,
+                        page_name=imgname,
+                        block_count=len(blk_list) if blk_list is not None else 0,
+                    )
                 elif getattr(cfg_module, 'skip_already_translated', False) and blk_list and all(
                     getattr(b, 'translation', None) and str(b.translation).strip() for b in blk_list
                 ):
                     self.translate_counter += 1
                     self.update_translate_progress.emit(self.translate_counter)
+                    log_diagnostic_event(
+                        "pipeline.translate_finish",
+                        page_index=page_num - 1,
+                        page_name=imgname,
+                        block_count=len(blk_list) if blk_list is not None else 0,
+                    )
                 elif self.parallel_trans:
                     self.translate_thread.push_pagekey_queue(imgname)
+                    log_diagnostic_event(
+                        "pipeline.translate_queued",
+                        page_index=page_num - 1,
+                        page_name=imgname,
+                        block_count=len(blk_list) if blk_list is not None else 0,
+                    )
                 elif not low_vram_trans:
                     self._set_translation_context_for_page(imgname, pages_to_iterate)
                     _series_path = (getattr(self.imgtrans_proj, "series_context_path", None) or "").strip()
@@ -1397,6 +1451,12 @@ class ImgtransThread(QThread):
                     self._append_page_to_series_context(imgname, blk_list)
                     self.translate_counter += 1
                     self.update_translate_progress.emit(self.translate_counter)
+                    log_diagnostic_event(
+                        "pipeline.translate_finish",
+                        page_index=page_num - 1,
+                        page_name=imgname,
+                        block_count=len(blk_list) if blk_list is not None else 0,
+                    )
                         
             if cfg_module.enable_inpaint:
                 LOGGER.info(f'Page {page_num}/{len(pages_to_iterate)}: inpainting (loading model if needed)')
@@ -1512,6 +1572,12 @@ class ImgtransThread(QThread):
                 self.translate_counter += 1
                 self.imgtrans_proj.update_page_progress(imgname, RunStatus.FIN_TRANSLATE)
                 self.update_translate_progress.emit(self.translate_counter)
+                log_diagnostic_event(
+                    "pipeline.translate_finish",
+                    page_index=page_num - 1,
+                    page_name=imgname,
+                    block_count=len(blk_list) if blk_list is not None else 0,
+                )
 
         try:
             from utils.batch_report import finalize_batch_report
@@ -2090,6 +2156,19 @@ class ModuleManager(QObject):
         self.ocr_thread.setOCR(ocr)
 
     def on_finish_translate_page(self, page_key: str):
+        page_index = -1
+        block_count = 0
+        if self.imgtrans_thread.imgtrans_proj is not None:
+            page_keys = list(self.imgtrans_thread.imgtrans_proj.pages.keys())
+            if page_key in page_keys:
+                page_index = page_keys.index(page_key)
+            block_count = len(self.imgtrans_thread.imgtrans_proj.pages.get(page_key, []) or [])
+        log_diagnostic_event(
+            "pipeline.translate_finish",
+            page_index=page_index,
+            page_name=page_key,
+            block_count=block_count,
+        )
         self.finish_translate_page.emit(page_key)
     
     def on_finish_inpaint(self, inpaint_dict: dict):

--- a/ui/scenetext_manager.py
+++ b/ui/scenetext_manager.py
@@ -17,7 +17,7 @@ from .textedit_area import TransTextEdit, SourceTextEdit, TransPairWidget, Selec
 from utils.fontformat import FontFormat, pt2px
 from .textedit_commands import propagate_user_edit, TextEditCommand, ReshapeItemCommand, MoveBlkItemsCommand, AutoLayoutCommand, ApplyFontformatCommand, RotateItemCommand, WarpItemCommand, TextItemEditCommand, TextEditCommand, PageReplaceOneCommand, PageReplaceAllCommand, MultiPasteCommand, ResetAngleCommand, SqueezeCommand
 from .text_panel import FontFormatPanel
-from utils.config import pcfg
+from utils.config import pcfg, log_diagnostic_event
 from utils import shared
 from utils.imgproc_utils import extract_ballon_region, rotate_polygons, get_block_mask, classify_bubble_shape_from_mask, mask_centroid_in_crop
 from utils.bubble_shape_model import get_bubble_shape_from_model as _bubble_shape_from_model_impl
@@ -841,6 +841,18 @@ class SceneTextManager(QObject):
         return textblk_item
 
     def deleteTextblkItemList(self, blkitem_list: List[TextBlkItem], p_widget_list: List[TransPairWidget]):
+        page_name = getattr(self.canvas.imgtrans_proj, 'current_img', None) if self.canvas.imgtrans_proj is not None else None
+        page_index = -1
+        if self.canvas.imgtrans_proj is not None and page_name in self.canvas.imgtrans_proj.pages:
+            page_keys = list(self.canvas.imgtrans_proj.pages.keys())
+            page_index = page_keys.index(page_name)
+        log_diagnostic_event(
+            "ui.blocks_delete",
+            page_name=page_name,
+            page_index=page_index,
+            block_ids=[blkitem.idx for blkitem in blkitem_list],
+            block_count=len(blkitem_list),
+        )
         selection_changed = False
         for blkitem, p_widget in zip(blkitem_list, p_widget_list):
             if blkitem.isSelected():
@@ -878,6 +890,18 @@ class SceneTextManager(QObject):
         self.textEditList.insertPairWidget(self.pairwidget_list[j], j)
 
     def recoverTextblkItemList(self, blkitem_list: List[TextBlkItem], p_widget_list: List[TransPairWidget]):
+        page_name = getattr(self.canvas.imgtrans_proj, 'current_img', None) if self.canvas.imgtrans_proj is not None else None
+        page_index = -1
+        if self.canvas.imgtrans_proj is not None and page_name in self.canvas.imgtrans_proj.pages:
+            page_keys = list(self.canvas.imgtrans_proj.pages.keys())
+            page_index = page_keys.index(page_name)
+        log_diagnostic_event(
+            "ui.blocks_recover",
+            page_name=page_name,
+            page_index=page_index,
+            block_ids=[blkitem.idx for blkitem in blkitem_list],
+            block_count=len(blkitem_list),
+        )
         self.canvas.block_selection_signal = True
         for blkitem, p_widget in zip(blkitem_list, p_widget_list):
             self.textblk_item_list.insert(blkitem.idx, blkitem)
@@ -2665,4 +2689,3 @@ def get_text_size(fm: QFontMetricsF, text: str) -> Tuple[int, int]:
     
 def get_words_length_list(fm: QFontMetricsF, words: List[str]) -> List[int]:
     return [int(np.ceil(fm.horizontalAdvance(word))) for word in words]
-

--- a/utils/config.py
+++ b/utils/config.py
@@ -492,6 +492,8 @@ class ProgramConfig(Config):
     model_packages_enabled: Optional[List[str]] = field(default_factory=lambda: ["core"])
     # When True, show all modules in detector/OCR/translator dropdowns (including not downloaded or incompatible). When False, only show ready modules.
     dev_mode: bool = False
+    # Temporary: when enabled, emit structured diagnostic logs for UI actions and pipeline stage transitions.
+    diagnostic_mode: bool = False
     shortcuts: Dict = field(default_factory=dict)
     auto_region_merge_after_run: str = 'never'  # 'never' | 'all_pages' | 'current_page'
     region_merge_settings: Dict = field(default_factory=dict)  # Region merge tool dialog (persisted)
@@ -608,6 +610,7 @@ CONFIG_KEY_ORDER = (
     "manga_source_translate_raw_search",
     "model_packages_enabled",
     "dev_mode",
+    "diagnostic_mode",
     "release_caches_after_batch", "manual_mode", "skip_ignored_in_run",
     "smooth_scroll_duration_ms", "motion_blur_on_scroll", "reduce_motion",
     "shortcuts", "auto_region_merge_after_run", "region_merge_settings", "context_menu", "context_menu_pinned",
@@ -620,6 +623,21 @@ def context_menu_visible(key: str) -> bool:
     if not hasattr(pcfg, 'context_menu') or not isinstance(pcfg.context_menu, dict):
         return True
     return pcfg.context_menu.get(key, True)
+
+
+def diagnostic_logging_enabled() -> bool:
+    return bool(getattr(pcfg, 'diagnostic_mode', False))
+
+
+def log_diagnostic_event(event: str, **payload):
+    """Emit one structured diagnostic log line when diagnostic mode is enabled."""
+    if not diagnostic_logging_enabled():
+        return
+    try:
+        formatted = json.dumps(payload, ensure_ascii=False, sort_keys=True, default=str)
+    except Exception:
+        formatted = str(payload)
+    LOGGER.info("DIAG|%s|%s", event, formatted)
 
 
 def load_textstyle_from(p: str, raise_exception = False):


### PR DESCRIPTION
### Motivation
- Add a short-lived diagnostic toggle to collect structured traces for triaging Issue #13 by capturing UI edit actions and pipeline stage transitions.
- Capture contextual metadata (page index/name, block counts, block ids) so maintainers can reproduce and reason about failures in detect/OCR/translate/edit flows.
- Provide a small maintainers’ template to request reproducible steps before adding a focused regression test and targeted fix.

### Description
- Added a temporary `diagnostic_mode` boolean on `ProgramConfig` and a helper `log_diagnostic_event(event, **payload)` in `utils/config.py` that emits structured `DIAG|<event>|<json>` logs only when `diagnostic_mode` is enabled, and included `diagnostic_mode` in `CONFIG_KEY_ORDER` so it persists with config saves. (`utils/config.py`)
- Instrumented UI undo/redo handlers in `ui/mainwindow.py` to call `log_diagnostic_event` with `page_index`, `page_name`, and current `block_count` when `on_undo` / `on_redo` are triggered so edit-history actions are captured. (`ui/mainwindow.py`)
- Instrumented the image-translation pipeline in `ui/module_manager.py` to emit diagnostics for `pipeline.page_start`, `pipeline.detect_start/finish`, `pipeline.ocr_start/finish`, `pipeline.translate_start/queued/finish` including `page_index`, `page_name`, and `block_count`; and emit a translate finish diagnostic when the async page-translate completion signal fires. (`ui/module_manager.py`)  
  - Where triggered: at pipeline loop start for each page and at the start/finish points of detect/OCR/translate stages.  
  - Why: to correlate stage transitions with project/page/block state when failures occur in different parts of the flow.  
  - Manual verification: enable `diagnostic_mode=true` in config, run a small translation run, and inspect logs for `DIAG|pipeline.*` and `DIAG|ui.*` lines containing JSON payloads.
- Instrumented scene text manager delete/recover flows to log `ui.blocks_delete` and `ui.blocks_recover` events carrying `page_name`, `page_index`, `block_ids`, and `block_count`. (`ui/scenetext_manager.py`)  
  - Where triggered: when blocks are deleted or recovered via context menu / commands.  
  - Manual verification: enable `diagnostic_mode=true`, delete and recover some blocks, and check for `DIAG|ui.blocks_*` log entries.
- Added `docs/ISSUE_13_REPRO_TEMPLATE_COMMENT.md` containing a short maintainer-facing template comment asking for exact repro steps, expected vs actual behavior, flow (detect/OCR/translate/edit), and suggesting enabling `diagnostic_mode` when available. (`docs/ISSUE_13_REPRO_TEMPLATE_COMMENT.md`)

### Testing
- Ran static compile checks with `python -m compileall -f -q utils/config.py ui/mainwindow.py ui/module_manager.py ui/scenetext_manager.py docs/ISSUE_13_REPRO_TEMPLATE_COMMENT.md`, which completed successfully.
- Attempted a small runtime smoke check by importing the diagnostic helper and toggling `pcfg.diagnostic_mode`, but the full runtime import failed in this environment due to a missing system dependency when importing OpenCV (`ImportError: libGL.so.1`), so GUI/runtime pipeline execution could not be validated here.
- No regression test added yet; per plan this PR only adds diagnostic hooks and the issue template—once reproducible steps for #13 are received we will add a focused deterministic test or script and then patch the confirmed failing path.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f02a250570832ca3c612f221263404)