### PR TITLE
docs: clarify startup entrypoints, troubleshooting, and diagnostics

### DIFF
--- a/Launch BallonsTranslator.bat
+++ b/Launch BallonsTranslator.bat
@@ -1,5 +1,5 @@
 @echo off
-REM Double-click this file to run the app with the project venv (not global Python).
+REM Source-clone launcher: run app with project venv only (venv\Scripts\python.exe, not global Python).
 REM For setup: py -3.10 -m venv venv  then  venv\Scripts\python.exe -m pip install -r requirements.txt
 setlocal
 cd /d "%~dp0"

--- a/README.md
+++ b/README.md
@@ -57,6 +57,24 @@ This fork adds **many new optional modules** (detectors, OCR engines, inpainters
 
 ---
 
+## Supported startup entrypoints
+
+Use one of these **official startup entrypoints**:
+
+1. `python launch.py`
+   - **Use for:** source clone on Windows/Linux/macOS, developer workflows, and CI-like diagnostics.
+   - **Behavior:** uses your current Python interpreter (`sys.executable`) and installs missing base dependencies on first run.
+
+2. `Launch BallonsTranslator.bat`
+   - **Use for:** source clone on Windows **after creating a local `venv`** in the repo root.
+   - **Behavior:** always runs `venv\Scripts\python.exe launch.py` so installs and runtime stay inside the project venv (avoids mixing with global Python).
+
+3. `launch_win*.bat` (`launch_win.bat`, `launch_win_with_autoupdate.bat`, `launch_win_amd_nightly.bat`)
+   - **Use for:** Windows **portable bundle layout** that includes `ballontrans_pylibs_win` (+ optional `PortableGit`).
+   - **Behavior:** prepends bundled portable Python paths, validates `python`/`pip`, then runs `launch.py` (optionally with `--update` or `--nightly`).
+
+> Rule of thumb: if you cloned the repo, start with `python launch.py` (or `Launch BallonsTranslator.bat` once venv exists). If you received a prepacked portable Windows bundle, use the matching `launch_win*.bat` script.
+
 ## Quick start
 
 1. **Clone and run:** `git clone https://github.com/thomaswantstobeaskeleton/BallonsTranslator-Pro.git && cd BallonsTranslator-Pro && python launch.py`
@@ -90,6 +108,53 @@ For a **portable-style** install (e.g. copy folder and run elsewhere):
    See **[docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md)** for GPU OOM, HuggingFace gated models, provider keys, and dependency conflicts.
 
 ---
+
+## Startup troubleshooting (entrypoint-level)
+
+| Symptom | Likely cause | What to run |
+|---|---|---|
+| `python` is not recognized | Python not installed or not on `PATH` | Install Python 3.10+ and verify with `python --version` (Windows may also use `py -V`). Then retry `python launch.py`. |
+| `No module named pip` / pip command fails | Broken or missing pip in selected interpreter | Run `python -m ensurepip --upgrade` then `python -m pip install --upgrade pip`. Retry startup command. |
+| `Launch BallonsTranslator.bat` says venv missing | `venv\Scripts\python.exe` does not exist | From repo root: `py -3.10 -m venv venv` then `venv\Scripts\python.exe -m pip install -r requirements.txt`, then rerun `Launch BallonsTranslator.bat`. |
+| Torch install fails on first launch | Network/index issue, incompatible wheel, or GPU stack mismatch | Retry with: `python launch.py --reinstall-torch`. If needed, set `TORCH_COMMAND` to a known-good install command, then rerun. See `docs/TROUBLESHOOTING.md` for CUDA/ROCm notes. |
+
+## Diagnostics mode (for startup failure reports)
+
+When reporting startup failures, include **exact command + full console output**.
+
+### A) Source clone (cross-platform)
+
+```bash
+python --version
+python -m pip --version
+python launch.py --debug --reinstall-torch
+```
+
+If launch fails, rerun with logging:
+
+```bash
+python launch.py --debug --reinstall-torch > startup_debug.log 2>&1
+```
+
+Attach `startup_debug.log` to the issue.
+
+### B) Windows source clone with venv launcher
+
+```bat
+venv\Scripts\python.exe --version
+venv\Scripts\python.exe -m pip --version
+Launch BallonsTranslator.bat --debug --reinstall-torch
+```
+
+### C) Windows portable bundle (`launch_win*.bat`)
+
+```bat
+launch_win.bat --debug > startup_portable.log 2>&1
+```
+
+(Or use `launch_win_with_autoupdate.bat` / `launch_win_amd_nightly.bat` for that specific bundle mode.)
+
+Include the generated log file plus OS + GPU information in the report.
 
 ## Key highlights (point by point)
 

--- a/launch_win.bat
+++ b/launch_win.bat
@@ -1,4 +1,4 @@
-@REM Launch BallonsTranslator on Windows (uses ballontrans_pylibs_win or system Python)
+@REM Launch BallonsTranslator for Windows portable bundle layout (prefers bundled ballontrans_pylibs_win Python on PATH).
 @REM @echo %PATH%
 
 cd %~dp0

--- a/launch_win_amd_nightly.bat
+++ b/launch_win_amd_nightly.bat
@@ -1,4 +1,4 @@
-@REM Launch BallonsTranslator on Windows (AMD/nightly)
+@REM Launch BallonsTranslator for Windows portable bundle layout with --nightly (AMD ROCm nightly mode).
 @REM @echo %PATH%
 
 cd %~dp0

--- a/launch_win_with_autoupdate.bat
+++ b/launch_win_with_autoupdate.bat
@@ -1,4 +1,4 @@
-@REM Launch BallonsTranslator on Windows with auto-update
+@REM Launch BallonsTranslator for Windows portable bundle layout with --update.
 @REM @echo %PATH%
 
 cd %~dp0

--- a/setup.bat
+++ b/setup.bat
@@ -1,5 +1,5 @@
 @echo off
-REM Section 11: Portable one-click setup (Windows)
+REM Windows source-clone setup helper (installs requirements for current Python or existing venv).
 REM Installs dependencies. PyTorch is auto-installed on first "python launch.py" run.
 
 setlocal


### PR DESCRIPTION
### Motivation

- Reduce user confusion about which startup path to use (source clone vs portable bundle) by documenting supported entrypoints and expected behavior. 
- Provide actionable, entrypoint-specific troubleshooting steps for common startup failures (missing Python, pip, venv, Torch install). 
- Give exact diagnostic commands so users can produce useful logs when reporting startup failures. 

### Description

- Add `## Supported startup entrypoints` to `README.md` that explicitly lists `python launch.py`, `Launch BallonsTranslator.bat`, and `launch_win*.bat` with guidance on when to use each and a short rule-of-thumb. 
- Add a `## Startup troubleshooting (entrypoint-level)` table to `README.md` covering `python` missing, `pip` missing, venv missing, and Torch install failures with concrete recovery commands. 
- Add a `## Diagnostics mode (for startup failure reports)` section to `README.md` with copy-paste commands for source clones, Windows venv usage, and portable bundle log capture. 
- Update top-of-file comments in `Launch BallonsTranslator.bat`, `launch_win.bat`, `launch_win_with_autoupdate.bat`, `launch_win_amd_nightly.bat`, and `setup.bat` so script headers match their actual behavior (comments only; no execution logic changes). 

### Testing

- Ran `python -m compileall -f -q launch.py`, which completed successfully. 
- Ran `python launch.py --help` to verify CLI option parsing and help text, which printed usage successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f02fc1da10832cae8a071a5c9f21c5)