### PR TITLE
Add user-facing model download presets, show sizes/usage/hints, and persist selection

### DIFF
--- a/launch.py
+++ b/launch.py
@@ -335,6 +335,7 @@ def main():
         dialog = ModelPackageSelectorDialog()
         dialog.exec()
         config.model_packages_enabled = dialog.get_selected_package_ids()
+        config.model_package_preset_ids = dialog.get_selected_preset_ids()
         try:
             from utils.config import save_config
             save_config()

--- a/ui/model_package_selector_dialog.py
+++ b/ui/model_package_selector_dialog.py
@@ -5,7 +5,6 @@ Only shown when config file did not exist (new user). User can select packages
 """
 from __future__ import annotations
 
-from qtpy.QtCore import Qt, Signal
 from qtpy.QtWidgets import (
     QDialog,
     QVBoxLayout,
@@ -13,13 +12,17 @@ from qtpy.QtWidgets import (
     QLabel,
     QPushButton,
     QCheckBox,
-    QScrollArea,
-    QWidget,
     QGroupBox,
-    QFrame,
+    QRadioButton,
 )
 
-from utils.model_packages import MODEL_PACKAGES, PACKAGE_LABELS
+from utils.model_packages import (
+    MODEL_PACKAGES,
+    MODEL_PACKAGE_PRESETS,
+    PACKAGE_LABELS,
+    DEFAULT_MODEL_PACKAGE_PRESET_ID,
+    get_package_ids_for_preset,
+)
 
 
 class ModelPackageSelectorDialog(QDialog):
@@ -28,9 +31,15 @@ class ModelPackageSelectorDialog(QDialog):
     def __init__(self, parent=None):
         super().__init__(parent)
         self.setWindowTitle(self.tr("Choose models to download"))
-        self.setMinimumSize(480, 340)
-        self.resize(520, 400)
+        self.setMinimumSize(560, 420)
+        self.resize(640, 500)
         self._checkboxes = {}
+        self._preset_radios = {}
+        self._advanced_mode_checkbox = None
+        self._presets_group = None
+        self._advanced_group = None
+        self._result = ["core"]
+        self._result_preset_ids = []
         self._build_ui()
 
     def _build_ui(self):
@@ -44,8 +53,44 @@ class ModelPackageSelectorDialog(QDialog):
         intro.setWordWrap(True)
         layout.addWidget(intro)
 
-        group = QGroupBox(self.tr("Model packages"))
-        group_layout = QVBoxLayout(group)
+        presets_group = QGroupBox(self.tr("Recommended presets"))
+        presets_layout = QVBoxLayout(presets_group)
+        for preset_id, preset in MODEL_PACKAGE_PRESETS.items():
+            label = preset.get("label", preset_id)
+            intended_use = preset.get("intended_use", "")
+            approx_size = preset.get("approx_size", "")
+            deps = preset.get("dependency_hints", "")
+            details = self.tr("Approx size: {size}. Use: {use}. Dependency hints: {deps}.").format(
+                size=approx_size,
+                use=intended_use,
+                deps=deps,
+            )
+            rb = QRadioButton(self.tr(label))
+            rb.setToolTip(details)
+            rb.setProperty("preset_id", preset_id)
+            self._preset_radios[preset_id] = rb
+            presets_layout.addWidget(rb)
+            details_label = QLabel(details)
+            details_label.setWordWrap(True)
+            details_label.setStyleSheet("color: #666; margin-left: 22px;")
+            presets_layout.addWidget(details_label)
+
+        default_rb = self._preset_radios.get(DEFAULT_MODEL_PACKAGE_PRESET_ID)
+        if default_rb is not None:
+            default_rb.setChecked(True)
+
+        self._presets_group = presets_group
+        layout.addWidget(presets_group)
+
+        self._advanced_mode_checkbox = QCheckBox(self.tr("Advanced/custom mode (power users)"))
+        self._advanced_mode_checkbox.setToolTip(
+            self.tr("Manually select low-level packages instead of using a preset.")
+        )
+        self._advanced_mode_checkbox.toggled.connect(self._sync_mode_ui)
+        layout.addWidget(self._advanced_mode_checkbox)
+
+        advanced_group = QGroupBox(self.tr("Manual package selection"))
+        group_layout = QVBoxLayout(advanced_group)
         for package_id in MODEL_PACKAGES:
             label, desc = PACKAGE_LABELS.get(package_id, (package_id, ""))
             cb = QCheckBox(self.tr(label))
@@ -55,7 +100,9 @@ class ModelPackageSelectorDialog(QDialog):
                 cb.setChecked(True)
             self._checkboxes[package_id] = cb
             group_layout.addWidget(cb)
-        layout.addWidget(group)
+        self._advanced_group = advanced_group
+        layout.addWidget(advanced_group)
+        self._sync_mode_ui(self._advanced_mode_checkbox.isChecked())
 
         btn_row = QHBoxLayout()
         btn_row.addStretch()
@@ -70,19 +117,48 @@ class ModelPackageSelectorDialog(QDialog):
         btn_row.addWidget(download_btn)
         layout.addLayout(btn_row)
 
+    def _sync_mode_ui(self, advanced_enabled: bool):
+        if self._advanced_group is not None:
+            self._advanced_group.setVisible(bool(advanced_enabled))
+        if self._presets_group is not None:
+            self._presets_group.setEnabled(not advanced_enabled)
+
+    def _selected_preset_id(self):
+        for pid, rb in self._preset_radios.items():
+            if rb.isChecked():
+                return pid
+        return DEFAULT_MODEL_PACKAGE_PRESET_ID
+
     def _selected_package_ids(self):
-        return [pid for pid, cb in self._checkboxes.items() if cb.isChecked()]
+        if self._advanced_mode_checkbox is not None and self._advanced_mode_checkbox.isChecked():
+            return [pid for pid, cb in self._checkboxes.items() if cb.isChecked()]
+        return get_package_ids_for_preset(self._selected_preset_id())
 
-    def _on_skip(self):
-        self._result = ["core"]
-        self.accept()
+    def _selected_preset_ids(self):
+        if self._advanced_mode_checkbox is not None and self._advanced_mode_checkbox.isChecked():
+            return ["custom"]
+        return [self._selected_preset_id()]
 
-    def _on_download(self):
+    def _accept_selection(self):
+        self._result_preset_ids = self._selected_preset_ids()
         self._result = self._selected_package_ids()
         if not self._result:
             self._result = ["core"]
+            self._result_preset_ids = ["core_minimal"]
+
+    def _on_skip(self):
+        self._result = ["core"]
+        self._result_preset_ids = ["core_minimal"]
+        self.accept()
+
+    def _on_download(self):
+        self._accept_selection()
         self.accept()
 
     def get_selected_package_ids(self):
-        """Return the selected package IDs (set after dialog is accepted)."""
+        """Return selected low-level package IDs (used by downloader)."""
         return getattr(self, "_result", ["core"])
+
+    def get_selected_preset_ids(self):
+        """Return selected preset ID(s) for reproducible setup metadata."""
+        return getattr(self, "_result_preset_ids", [])

--- a/utils/config.py
+++ b/utils/config.py
@@ -490,6 +490,8 @@ class ProgramConfig(Config):
     manga_source_translate_raw_search: bool = True  # For raw sources: translate search query to Japanese/Korean/Chinese
     # Model packages to download at startup (None = legacy "all"; ["core"] = minimal). See utils.model_packages.
     model_packages_enabled: Optional[List[str]] = field(default_factory=lambda: ["core"])
+    # User-facing preset IDs selected on first run (or ["custom"] for manual package selection).
+    model_package_preset_ids: List[str] = field(default_factory=lambda: ["balanced_default"])
     # When True, show all modules in detector/OCR/translator dropdowns (including not downloaded or incompatible). When False, only show ready modules.
     dev_mode: bool = False
     # Temporary: when enabled, emit structured diagnostic logs for UI actions and pipeline stage transitions.
@@ -563,6 +565,8 @@ class ProgramConfig(Config):
         # Legacy: configs that lack this key or have null used to download all models. Default to core-only (Issue #15).
         if config_dict.get("model_packages_enabled") is None:
             config_dict["model_packages_enabled"] = ["core"]
+        if not config_dict.get("model_package_preset_ids"):
+            config_dict["model_package_preset_ids"] = ["balanced_default"]
 
         return ProgramConfig(**config_dict)
     
@@ -608,7 +612,7 @@ CONFIG_KEY_ORDER = (
     "manga_source_lang", "manga_source_data_saver", "manga_source_download_dir",
     "manga_source_request_delay", "manga_source_open_after_download", "manga_source_playwright_headless",
     "manga_source_translate_raw_search",
-    "model_packages_enabled",
+    "model_packages_enabled", "model_package_preset_ids",
     "dev_mode",
     "diagnostic_mode",
     "release_caches_after_batch", "manual_mode", "skip_ignored_in_run",

--- a/utils/model_packages.py
+++ b/utils/model_packages.py
@@ -1,13 +1,13 @@
 """
-Model packages for selective download at first launch (Issue #15).
+Model packages and user-facing presets for first-launch selective download.
 
-Packages group modules so users can choose e.g. "Core" only (~hundreds MB)
-instead of auto-downloading everything including PaddleOCR-VL (~1.7 GB).
-None = legacy "download all" for existing installs; ["core"] = minimal default for new users.
+`MODEL_PACKAGES` remains the low-level module grouping consumed by download logic.
+`MODEL_PACKAGE_PRESETS` adds user-centered curated bundles (fast start, balanced,
+OCR-heavy, etc.) so the UI can explain tradeoffs and dependency hints clearly.
 """
 from __future__ import annotations
 
-from typing import List, Optional, Tuple, Any
+from typing import Dict, List, Optional, Any
 
 # Registry name -> module_key. pkuseg is a special key (handled in prepare_local_files).
 MODEL_PACKAGES = {
@@ -36,13 +36,62 @@ MODEL_PACKAGES = {
     ],
 }
 
-# Human-readable labels and short descriptions for the first-launch dialog
+# Human-readable labels and short descriptions for package-level advanced/custom mode.
 PACKAGE_LABELS = {
-    "core": ("Core (recommended)", "Text detection, inpainting, OCR, pkuseg — minimal to run"),
+    "core": ("Core package", "Text detection, inpainting, OCR, pkuseg — minimal to run"),
     "advanced_ocr": ("Advanced OCR", "PaddleOCR-VL for manga (~1.7 GB), MIT 48px/32px"),
     "advanced_inpaint": ("Advanced inpainting", "LaMa variants, ONNX, PatchMatch"),
     "optional_onnx": ("Optional ONNX inpainting", "Lama 2025 / lama-manga ONNX (smaller, CPU-friendly)"),
 }
+
+# User-centered presets surfaced in the first-launch dialog.
+# package_ids is intentionally explicit to keep setup reproducible.
+MODEL_PACKAGE_PRESETS: Dict[str, Dict[str, Any]] = {
+    "core_minimal": {
+        "label": "Core minimal (fast start)",
+        "intended_use": "Smallest useful setup for quick first run and low disk usage.",
+        "approx_size": "~0.7 GB",
+        "package_ids": ["core"],
+        "dependency_hints": "No extra runtime dependencies expected beyond base install.",
+    },
+    "balanced_default": {
+        "label": "Balanced default",
+        "intended_use": "Recommended for most users: solid OCR + inpaint quality without huge downloads.",
+        "approx_size": "~2.5 GB",
+        "package_ids": ["core", "advanced_inpaint"],
+        "dependency_hints": "Large download; ONNX inpaint variants run best with onnxruntime(-gpu) when available.",
+    },
+    "ocr_heavy": {
+        "label": "OCR-heavy",
+        "intended_use": "Best OCR coverage/accuracy for diverse manga text styles and mixed languages.",
+        "approx_size": "~4.2 GB",
+        "package_ids": ["core", "advanced_ocr"],
+        "dependency_hints": "Very large download. PaddleOCR-VL may require extra runtime wheels depending on platform/device.",
+    },
+    "inpaint_heavy": {
+        "label": "Inpaint-heavy",
+        "intended_use": "More inpainting backends for harder backgrounds, speed/quality experiments, and CPU fallback.",
+        "approx_size": "~3.0 GB",
+        "package_ids": ["core", "advanced_inpaint", "optional_onnx"],
+        "dependency_hints": "Large download. ONNX variants benefit from onnxruntime(-gpu); PatchMatch is CPU-heavy on big pages.",
+    },
+    "video_focused_optional": {
+        "label": "Video-focused optional",
+        "intended_use": "Optional add-on for video/comic workflows that favor broader OCR + inpaint compatibility.",
+        "approx_size": "~5.0 GB",
+        "package_ids": ["core", "advanced_ocr", "advanced_inpaint", "optional_onnx"],
+        "dependency_hints": "Largest download. Recommended only with stable bandwidth/storage and optional GPU runtimes.",
+    },
+}
+
+DEFAULT_MODEL_PACKAGE_PRESET_ID = "balanced_default"
+
+
+def get_package_ids_for_preset(preset_id: str) -> List[str]:
+    preset = MODEL_PACKAGE_PRESETS.get(preset_id)
+    if preset is None:
+        return []
+    return list(preset.get("package_ids") or [])
 
 
 def get_module_classes_for_packages(


### PR DESCRIPTION
### Motivation
- Make first-run model selection more user-centered by exposing curated presets with clear tradeoffs (disk size, intended use, dependency hints) so users can pick an appropriate bundle quickly.
- Preserve the existing low-level package grouping and power-user workflow by keeping manual package selection (advanced/custom mode) available and reproducible.
- Persist preset metadata to config so first-run choices are reproducible and can be inspected or re-used later.

### Description
- Added user-facing preset definitions in `utils/model_packages.py`: `MODEL_PACKAGE_PRESETS` with entries for `core_minimal`, `balanced_default`, `ocr_heavy`, `inpaint_heavy`, and `video_focused_optional`, plus `DEFAULT_MODEL_PACKAGE_PRESET_ID` and helper `get_package_ids_for_preset()`; existing `MODEL_PACKAGES` is unchanged and remains the low-level grouping.
- Extended the first-run dialog `ui/model_package_selector_dialog.py` to display recommended presets with approximate disk size, intended use, and dependency hints, to default-select the balanced preset, and to keep an `Advanced/custom mode` checkbox which reveals the existing manual low-level package checkboxes; dialog now returns both low-level package IDs (`get_selected_package_ids()`) and preset ID(s) (`get_selected_preset_ids()`).
- Persisted chosen preset id(s) in configuration by adding `model_package_preset_ids` to `ProgramConfig` in `utils/config.py` (with backward-compatible defaults in `load`) and added it to the canonical save order.
- Wired the first-run flow in `launch.py` to save both `config.model_packages_enabled` and `config.model_package_preset_ids` after the dialog completes so the selection is stored for reproducible setup.

Where this is triggered and how to verify manually: the dialog appears on first-run when `shared.FIRST_RUN_NO_CONFIG` is true; open the app on a fresh configuration and verify the "Recommended presets" section lists presets with size/use/dependency hints, that the default preset is checked, that toggling "Advanced/custom mode" reveals the manual package checkboxes, and that after acceptance `config.json` contains both `model_packages_enabled` and `model_package_preset_ids` matching the selection.

### Testing
- Ran `python -m compileall -f -q utils/model_packages.py ui/model_package_selector_dialog.py utils/config.py launch.py` and compilation succeeded.
- Ran a non-UI smoke test: `from utils.model_packages import MODEL_PACKAGE_PRESETS, get_package_ids_for_preset` and verified `get_package_ids_for_preset('balanced_default') == ['core', 'advanced_inpaint']` and `get_package_ids_for_preset('core_minimal') == ['core']` (passed).
- Attempted an offscreen Qt dialog smoke check (`QT_QPA_PLATFORM=offscreen`) but the container lacked `libGL.so.1`, so UI instantiation could not be exercised here (environment limitation); recommend an in-environment manual smoke run or CI GUI-capable test to confirm full dialog behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f02fc39c68832c9291289f8bf46444)