### PR TITLE
Model manager: surface module metadata, human-readable labels, filters, and download size/paths

### DIFF
--- a/ui/model_manager_dialog.py
+++ b/ui/model_manager_dialog.py
@@ -25,6 +25,8 @@ from qtpy.QtWidgets import (
     QHeaderView,
     QAbstractItemView,
     QGridLayout,
+    QLineEdit,
+    QComboBox,
 )
 
 from utils.model_manager import (
@@ -100,6 +102,7 @@ class ModelManagerDialog(QDialog):
         self._download_thread = None
         self._download_worker = None
         self._module_infos = []
+        self._check_results: List[Dict[str, Any]] = []
         self._check_boxes: List[QCheckBox] = []
         self._build_ui()
 
@@ -123,6 +126,20 @@ class ModelManagerDialog(QDialog):
         self.checkProgress.setRange(0, 0)
         self.checkProgress.setVisible(False)
         check_layout.addWidget(self.checkProgress)
+        filter_row = QHBoxLayout()
+        self.searchEdit = QLineEdit()
+        self.searchEdit.setPlaceholderText(self.tr('Search module key/name/description…'))
+        self.searchEdit.textChanged.connect(self._apply_result_filters)
+        filter_row.addWidget(self.searchEdit, 2)
+        self.categoryFilter = QComboBox()
+        self.categoryFilter.addItem(self.tr('All categories'), '')
+        self.categoryFilter.currentIndexChanged.connect(self._apply_result_filters)
+        filter_row.addWidget(self.categoryFilter, 1)
+        self.statusFilter = QComboBox()
+        self.statusFilter.addItem(self.tr('All statuses'), '')
+        self.statusFilter.currentIndexChanged.connect(self._apply_result_filters)
+        filter_row.addWidget(self.statusFilter, 1)
+        check_layout.addLayout(filter_row)
         self.resultTable = QTableWidget()
         self.resultTable.setColumnCount(4)
         self.resultTable.setHorizontalHeaderLabels([
@@ -183,6 +200,7 @@ class ModelManagerDialog(QDialog):
             if not mod['can_download']:
                 continue
             cb = QCheckBox(mod['display_name'])
+            cb.setToolTip(self._build_module_tooltip(mod))
             cb.setProperty('module_info', mod)
             self.downloadCheckboxLayout.addWidget(cb, row, col)
             self._check_boxes.append(cb)
@@ -225,24 +243,9 @@ class ModelManagerDialog(QDialog):
             'no_download_list': self.tr('No file list'),
             'download_on_load': self.tr('Download on load'),
         }
-        self.resultTable.setRowCount(len(results))
-        for row, r in enumerate(results):
-            mod = r['module_info']
-            self.resultTable.setItem(row, 0, QTableWidgetItem(mod['category_label']))
-            self.resultTable.setItem(row, 1, QTableWidgetItem(mod['display_name']))
-            st = r['status']
-            status_str = status_text.get(st, st)
-            if st == 'no_download_list' and r.get('details') and any(r['details']):
-                status_str = self.tr('Optional')
-            if r.get('import_error'):
-                status_str = self.tr('Incompatible')
-            self.resultTable.setItem(row, 2, QTableWidgetItem(status_str))
-            details = '; '.join(r['details'][:5])
-            if r.get('import_error'):
-                details = r['import_error'][:200] + ('…' if len(r['import_error']) > 200 else '')
-            elif len(r['details']) > 5:
-                details += '…'
-            self.resultTable.setItem(row, 3, QTableWidgetItem(details))
+        self._check_results = results
+        self._refresh_filter_options()
+        self._apply_result_filters()
 
     def _on_check_error(self, msg: str):
         if self._check_thread and self._check_thread.isRunning():
@@ -307,3 +310,128 @@ class ModelManagerDialog(QDialog):
             self._download_thread.quit()
             self._download_thread.wait(1000)
         super().closeEvent(event)
+
+    def _refresh_filter_options(self):
+        current_category = self.categoryFilter.currentData()
+        current_status = self.statusFilter.currentData()
+        categories = sorted({r['module_info'].get('category_label', '') for r in self._check_results if r.get('module_info')})
+        self.categoryFilter.blockSignals(True)
+        self.categoryFilter.clear()
+        self.categoryFilter.addItem(self.tr('All categories'), '')
+        for c in categories:
+            self.categoryFilter.addItem(c, c)
+        idx = self.categoryFilter.findData(current_category)
+        if idx >= 0:
+            self.categoryFilter.setCurrentIndex(idx)
+        self.categoryFilter.blockSignals(False)
+
+        status_entries = [
+            ('ok', self.tr('Downloaded')),
+            ('missing', self.tr('Missing')),
+            ('hash_mismatch', self.tr('Hash mismatch')),
+            ('no_download_list', self.tr('No file list')),
+            ('download_on_load', self.tr('Download on load')),
+            ('incompatible', self.tr('Incompatible')),
+            ('optional', self.tr('Optional')),
+        ]
+        self.statusFilter.blockSignals(True)
+        self.statusFilter.clear()
+        self.statusFilter.addItem(self.tr('All statuses'), '')
+        for key, label in status_entries:
+            self.statusFilter.addItem(label, key)
+        idx = self.statusFilter.findData(current_status)
+        if idx >= 0:
+            self.statusFilter.setCurrentIndex(idx)
+        self.statusFilter.blockSignals(False)
+
+    def _apply_result_filters(self):
+        text = (self.searchEdit.text() or '').strip().lower()
+        category = self.categoryFilter.currentData() or ''
+        status_filter = self.statusFilter.currentData() or ''
+        status_text = {
+            'ok': self.tr('Downloaded'),
+            'missing': self.tr('Missing'),
+            'hash_mismatch': self.tr('Hash mismatch'),
+            'no_download_list': self.tr('No file list'),
+            'download_on_load': self.tr('Download on load'),
+        }
+        filtered = []
+        for r in self._check_results:
+            mod = r.get('module_info', {})
+            raw_status = r.get('status', '')
+            effective_status = raw_status
+            if raw_status == 'no_download_list' and r.get('details') and any(r.get('details', [])):
+                effective_status = 'optional'
+            if r.get('import_error'):
+                effective_status = 'incompatible'
+            if category and mod.get('category_label') != category:
+                continue
+            if status_filter and effective_status != status_filter:
+                continue
+            haystack = ' '.join([
+                str(mod.get('module_key', '')),
+                str(mod.get('human_name', '')),
+                str(mod.get('display_name', '')),
+                str(mod.get('description', '')),
+                str(mod.get('category_label', '')),
+            ]).lower()
+            if text and text not in haystack:
+                continue
+            filtered.append(r)
+
+        self.resultTable.setRowCount(len(filtered))
+        for row, r in enumerate(filtered):
+            mod = r['module_info']
+            self.resultTable.setItem(row, 0, QTableWidgetItem(mod.get('category_label', '')))
+            module_item = QTableWidgetItem(mod.get('display_name', mod.get('module_key', '')))
+            module_item.setToolTip(self._build_module_tooltip(mod))
+            self.resultTable.setItem(row, 1, module_item)
+            st = r['status']
+            status_str = status_text.get(st, st)
+            if st == 'no_download_list' and r.get('details') and any(r['details']):
+                status_str = self.tr('Optional')
+            if r.get('import_error'):
+                status_str = self.tr('Incompatible')
+            self.resultTable.setItem(row, 2, QTableWidgetItem(status_str))
+            details = '; '.join(r['details'][:5])
+            if r.get('import_error'):
+                details = r['import_error'][:200] + ('…' if len(r['import_error']) > 200 else '')
+            elif len(r['details']) > 5:
+                details += '…'
+            extra = []
+            size_text = self._format_size(mod.get('estimated_download_size_bytes'))
+            if size_text:
+                extra.append(self.tr('Estimated size: {0}').format(size_text))
+            target_paths = mod.get('target_paths') or []
+            if target_paths:
+                extra.append(self.tr('Target: {0}').format(target_paths[0]))
+            if extra:
+                details = (details + ' | ' if details else '') + ' | '.join(extra)
+            self.resultTable.setItem(row, 3, QTableWidgetItem(details))
+
+    def _build_module_tooltip(self, mod: Dict[str, Any]) -> str:
+        tip = [self.tr('Key: {0}').format(mod.get('module_key', ''))]
+        desc = (mod.get('description') or '').strip()
+        if desc:
+            tip.append(desc)
+        size_text = self._format_size(mod.get('estimated_download_size_bytes'))
+        if size_text:
+            tip.append(self.tr('Estimated size: {0}').format(size_text))
+        target_paths = mod.get('target_paths') or []
+        if target_paths:
+            preview = ', '.join(target_paths[:3])
+            if len(target_paths) > 3:
+                preview += ', …'
+            tip.append(self.tr('Target path(s): {0}').format(preview))
+        return '\n'.join([t for t in tip if t])
+
+    def _format_size(self, size_bytes: Any) -> str:
+        if not isinstance(size_bytes, (int, float)) or size_bytes <= 0:
+            return ''
+        units = ['B', 'KB', 'MB', 'GB', 'TB']
+        size = float(size_bytes)
+        for unit in units:
+            if size < 1024 or unit == units[-1]:
+                return f'{size:.1f} {unit}' if unit != 'B' else f'{int(size)} B'
+            size /= 1024.0
+        return ''

--- a/utils/model_manager.py
+++ b/utils/model_manager.py
@@ -173,7 +173,15 @@ def get_all_downloadable_modules() -> List[Dict[str, Any]]:
     Manage models dialog. Includes every module so optional/pip-only modules (e.g.
     Nemotron) appear in the check table. can_download is True only when the module
     has a download_file_list and not download_file_on_load.
-    Returns a list of dicts: category_label, display_name, module_class, can_download.
+    Returns a list of dicts:
+      - category_label
+      - module_key
+      - display_name
+      - description
+      - module_class
+      - can_download
+      - estimated_download_size_bytes (optional)
+      - target_paths (relative/absolute paths where available)
     """
     from modules import INPAINTERS, TEXTDETECTORS, OCR, TRANSLATORS
 
@@ -189,17 +197,100 @@ def get_all_downloadable_modules() -> List[Dict[str, Any]]:
             module_class = registry.get(module_key)
             if module_class is None:
                 continue
+            params = getattr(module_class, "params", None) or {}
+            human_name = _extract_human_name(module_key, module_class, params)
+            description = _extract_module_description(params)
             has_list = getattr(module_class, "download_file_list", None) is not None
             on_load = getattr(module_class, "download_file_on_load", False)
-            display_name = module_key
+            display_name = f"{category_label} · {human_name} ({module_key})"
             can_download = has_list and not on_load
+            dl_meta = _extract_download_metadata(module_class)
             result.append({
                 "category_label": category_label,
+                "module_key": module_key,
                 "display_name": display_name,
+                "human_name": human_name,
+                "description": description,
                 "module_class": module_class,
                 "can_download": can_download,
+                "estimated_download_size_bytes": dl_meta["estimated_download_size_bytes"],
+                "target_paths": dl_meta["target_paths"],
             })
     return result
+
+
+def _extract_human_name(module_key: str, module_class: Any, params: Dict[str, Any]) -> str:
+    """Try to extract user-facing module name from params/class metadata."""
+    for key in ("display_name", "name", "title", "label"):
+        val = params.get(key)
+        if isinstance(val, str) and val.strip():
+            return val.strip()
+        if isinstance(val, dict):
+            v = val.get("value")
+            if isinstance(v, str) and v.strip():
+                return v.strip()
+    class_name = getattr(module_class, "__name__", "") or ""
+    return class_name or module_key
+
+
+def _extract_module_description(params: Dict[str, Any]) -> str:
+    desc = params.get("description")
+    if isinstance(desc, str):
+        return desc.strip()
+    if isinstance(desc, dict):
+        v = desc.get("value")
+        if isinstance(v, str):
+            return v.strip()
+    return ""
+
+
+def _extract_download_metadata(module_class: Any) -> Dict[str, Any]:
+    """
+    Extract optional metadata from download_file_list.
+    Supports best-effort keys to keep backward compatibility:
+      estimated_size_bytes / size_bytes / download_size_bytes / estimated_total_size_bytes.
+    """
+    dl_list = getattr(module_class, "download_file_list", None) or []
+    target_paths: List[str] = []
+    total_size = 0
+    has_size = False
+    for entry in dl_list:
+        if not isinstance(entry, dict):
+            continue
+        target_paths.extend(_extract_target_paths_from_entry(entry))
+        for key in ("estimated_size_bytes", "size_bytes", "download_size_bytes", "estimated_total_size_bytes"):
+            value = entry.get(key)
+            if isinstance(value, (int, float)):
+                total_size += int(value)
+                has_size = True
+        file_sizes = entry.get("file_sizes")
+        if isinstance(file_sizes, list):
+            for size in file_sizes:
+                if isinstance(size, (int, float)):
+                    total_size += int(size)
+                    has_size = True
+    return {
+        "estimated_download_size_bytes": total_size if has_size else None,
+        "target_paths": target_paths,
+    }
+
+
+def _extract_target_paths_from_entry(entry: Dict[str, Any]) -> List[str]:
+    files = entry.get("save_files")
+    if files is None:
+        files = entry.get("files")
+    if files is None:
+        return []
+    if isinstance(files, str):
+        file_list = [files]
+    elif isinstance(files, list):
+        file_list = [f for f in files if isinstance(f, str)]
+    else:
+        return []
+    save_dir = entry.get("save_dir")
+    if isinstance(save_dir, str) and save_dir.strip():
+        return [osp.join(save_dir, f) for f in file_list]
+    return file_list
 
 
 def get_available_module_keys(registry) -> List[str]:


### PR DESCRIPTION
### Motivation
- Improve discoverability and debugging for downloadable modules by surfacing human-friendly names and descriptions where available instead of raw keys.
- Allow users to quickly find modules in the Manage Models dialog by category/status or free-text search.
- Show estimated download size and intended target path(s) when available to help users decide what to download.

### Description
- `utils/model_manager.get_all_downloadable_modules()` now returns richer metadata per module including `module_key`, `human_name`, `description`, `estimated_download_size_bytes`, and `target_paths`, and builds the display label as `Category · Human name (module_key)`; helper extractors `_extract_human_name`, `_extract_module_description`, `_extract_download_metadata`, and `_extract_target_paths_from_entry` were added to parse params/download specs. (changes in `utils/model_manager.py`)
- `ui/model_manager_dialog.py` now adds a search box plus category and status filters above the check results and wires dynamic filtering to the results after `check_all_models()` completes; module cells and download checkboxes include tooltips that keep the module key visible and show description/estimated size/target path when present. (changes in `ui/model_manager_dialog.py`)
- The results table’s Details column appends best-effort "Estimated size" and a primary "Target" path when metadata exists, and the download checkbox labels use the new humanized display string.
- UX notes: the Manage Models dialog changes are triggered from Tools → Manage models (Check model files section), were added to keep the top-level dialog layout unchanged, and can be manually verified by running the dialog, clicking `Check all models`, then exercising the search, category, and status selectors to confirm filtering and tooltip content.

### Testing
- Ran static runtime checks via `python -m compileall -f -q utils/model_manager.py ui/model_manager_dialog.py` and the compilation succeeded.
- Attempted a headless/UI smoke check by instantiating `ModelManagerDialog` with `QT_QPA_PLATFORM=offscreen`, but it failed to import Qt due to a missing system library (`libGL.so.1`), so interactive verification on CI/desktop was blocked by the environment rather than code errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f02fcd4050832c8e03d742376faa2b)