### PR TITLE
Add PR template enforcing README parity, startup and first-run model-picker checks

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,35 @@
+## Summary
+- What changed?
+- Why is this needed?
+
+## Required Checks
+
+### README parity (EN + ZH)
+- [ ] I reviewed [`README.md`](../README.md) and [`README_zh_CN.md`](../README_zh_CN.md) and confirmed they are in parity for any user-facing changes in this PR.
+- [ ] If one README was updated without the other, I explained why.
+
+### Startup script verification
+- [ ] Verified startup behavior and entry points as applicable:
+  - [ ] [`launch.py`](../launch.py)
+  - [ ] [`launch_win.bat`](../launch_win.bat)
+  - [ ] [`launch_win_with_autoupdate.bat`](../launch_win_with_autoupdate.bat)
+  - [ ] [`launch_win_amd_nightly.bat`](../launch_win_amd_nightly.bat)
+- [ ] Included a brief verification result for each script touched by this PR.
+
+### First-run model-picker verification
+- [ ] Verified first-run model package selection flow end-to-end where applicable:
+  - [ ] [`utils/model_packages.py`](../utils/model_packages.py)
+  - [ ] [`ui/model_package_selector_dialog.py`](../ui/model_package_selector_dialog.py)
+- [ ] Confirmed behavior for first launch, model package listing, selection, and persistence.
+- [ ] Included before/after screenshots for any UI change to the first-run model dialog.
+
+## UX / Behavior Validation
+- [ ] For UX-facing changes, I documented a clear **manual verification path** (steps + expected result).
+- [ ] If defaults changed, I explained the **migration impact** for existing users/configurations.
+
+## Risks / Compatibility
+- Potential regressions:
+- Rollback notes (if needed):
+
+## Additional Notes
+- Environment limitations (if any):


### PR DESCRIPTION
### Motivation
- Introduce a standard PR checklist to enforce EN/ZH README parity, startup script verification, first-run model-picker verification, migration-impact notes for changed defaults, explicit manual verification paths for UX changes, and before/after screenshots for first-run model dialog UI changes.

### Description
- Add `.github/PULL_REQUEST_TEMPLATE.md` containing required checks and direct links to `README.md`, `README_zh_CN.md`, `launch.py`, `launch_win.bat`, `launch_win_with_autoupdate.bat`, `launch_win_amd_nightly.bat`, `utils/model_packages.py`, and `ui/model_package_selector_dialog.py`.

### Testing
- Ran `python -m compileall -f -q .github/PULL_REQUEST_TEMPLATE.md` which completed successfully, and no runtime code paths were modified so no further automated runtime tests were required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f02fd6c1c4832cbc3cdd759e0e4df2)