### PR TITLE
Add module tier system, stable-first startup ordering, and canonical compatibility matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -697,6 +697,19 @@ On **AMD** GPUs you can use either **ZLUDA** (translation layer, works with the 
 
 ---
 
+## Module tiers & compatibility
+
+Tier definitions used across docs/UI:
+
+| Tier | Meaning |
+|---|---|
+| **Stable** | Best-tested defaults and first-run presets. |
+| **Beta** | Good coverage, but less battle-tested across environments. |
+| **Experimental** | New/stub/high-variance modules. |
+| **External dependency heavy** | Requires heavier optional stacks or external repos/APIs. |
+
+Canonical matrix: **[docs/MODULE_COMPATIBILITY_MATRIX.md](docs/MODULE_COMPATIBILITY_MATRIX.md)**.
+
 ## 3. Text detection – all modules and how to run
 
 Select the detector from the **Text detection** dropdown in the settings panel. Pair detection-only modules with an OCR (see [INSTALL_EXTRA_DETECTORS.md](docs/INSTALL_EXTRA_DETECTORS.md) for which work with **none_ocr**).
@@ -705,29 +718,29 @@ Select the detector from the **Text detection** dropdown in the settings panel. 
 
 ### Original / built-in
 
-| Module | How to run | Notes |
-|--------|-------------|--------|
-| **ctd** | Select **ctd**; set device, detect_size, box score threshold, merge tolerance, etc. | ComicTextDetector; primary manga detector. See [Settings](#71-ctd-comictextdetector) below. |
-| **paddle_det** | Select **paddle_det**; needs `paddlepaddle`, `paddleocr`. | Paddle OCR detection; pair with paddle_ocr or paddle_rec_v5. |
-| **easyocr_det** | Select **easyocr_det**; needs `easyocr`. | CRAFT-based; pair with easyocr_ocr. |
-| **ysgyolo** | Select **ysgyolo**; put YOLO `.pt` in `data/models/` with name starting with `ysgyolo` (e.g. ogkalu's `ysgyolo_comic_speech_bubble_v8m.pt`, or YSG 淫書館 models from [YSGforMTL/YSGYoloDetector](https://huggingface.co/YSGforMTL/YSGYoloDetector)). | For comic bubble detection; pair with any OCR. **YSG series** = YSGforMTL only; other .pt (ogkalu, Kiuyha, etc.) are not YSG. |
-| **stariver_ocr** | Select **stariver_ocr**; fill User/Password in params. | API returns boxes+text; set OCR to **none_ocr**. |
+| Module | Tier | How to run | Notes |
+|--------|------|-------------|--------|
+| **ctd** | **Stable** | Select **ctd**; set device, detect_size, box score threshold, merge tolerance, etc. | ComicTextDetector; primary manga detector. See [Settings](#71-ctd-comictextdetector) below. |
+| **paddle_det** | **Stable** | Select **paddle_det**; needs `paddlepaddle`, `paddleocr`. | Paddle OCR detection; pair with paddle_ocr or paddle_rec_v5. |
+| **easyocr_det** | **Beta** | Select **easyocr_det**; needs `easyocr`. | CRAFT-based; pair with easyocr_ocr. |
+| **ysgyolo** | **Beta** | Select **ysgyolo**; put YOLO `.pt` in `data/models/` with name starting with `ysgyolo` (e.g. ogkalu's `ysgyolo_comic_speech_bubble_v8m.pt`, or YSG 淫書館 models from [YSGforMTL/YSGYoloDetector](https://huggingface.co/YSGforMTL/YSGYoloDetector)). | For comic bubble detection; pair with any OCR. **YSG series** = YSGforMTL only; other .pt (ogkalu, Kiuyha, etc.) are not YSG. |
+| **stariver_ocr** | **External dependency heavy** | Select **stariver_ocr**; fill User/Password in params. | API returns boxes+text; set OCR to **none_ocr**. |
 
 ### New in this fork
 
-| Module | Dependencies | How to run |
-|--------|--------------|------------|
-| **hf_object_det** | `pip install transformers torch` | Select **hf_object_det**. Default **model_id** is `ogkalu/comic-text-and-bubble-detector` (bubble, text_bubble, text_free). Change **model_id** for other HF object-detection models; use **score_threshold** and **labels_include** (comma-separated) to filter. |
-| **mmocr_det** | `pip install openmim` then `mim install mmengine mmcv mmdet mmocr` (see `doc/INSTALL_MMOCR.md` for Windows). | Select **mmocr_det**; pair with mmocr_ocr. |
-| **paddle_det_v5** | `pip install paddlepaddle paddleocr` (3.x). | Select **paddle_det_v5**; pair with paddle_rec_v5. |
-| **surya_det** | `pip install surya-ocr` | Select **surya_det**; pair with surya_ocr. |
-| **magi_det** | `pip install transformers torch einops` | Select **magi_det**; model downloads from HF (ragavsachdeva/magi) on first use; pair with any OCR. |
-| **craft_det** | `pip install craft-text-detector torch` | Select **craft_det**; outputs 4-point quads for merge; pair with any OCR. **Conflict:** needs opencv<4.5.4.62; see [Optional dependencies](#8-optional-dependency-conflicts-and-workarounds). |
-| **rapidocr_det** | `pip install rapidocr-onnxruntime` | Select **rapidocr_det**; lightweight ONNX detection; pair with **rapidocr** OCR for EasyScanlate-like pipeline. Optional models in `data/models/rapidocr/`. See docs/OPTIONAL_DEPENDENCIES.md. |
-| **dptext_detr** | Clone [DPText-DETR](https://github.com/ymy-k/DPText-DETR), install its deps. | Select **dptext_detr**; set **repo_path** to your clone; pair with any OCR. |
-| **swintextspotter_v2** | Clone [SwinTextSpotterv2](https://github.com/mxin262/SwinTextSpotterv2), install its deps. | Select **swintextspotter_v2**; set **repo_path**; use **none_ocr** if demo outputs text. |
-| **hunyuan_ocr_det** | Same as hunyuan_ocr (transformers, etc.). | Select **hunyuan_ocr_det**; set OCR to **none_ocr** to keep spotter text. |
-| **textmamba_det** | None (stub) | Selecting it raises an error until official code is released; use mmocr_det or surya_det meanwhile. |
+| Module | Tier | Dependencies | How to run |
+|--------|------|--------------|------------|
+| **hf_object_det** | **Beta** | `pip install transformers torch` | Select **hf_object_det**. Default **model_id** is `ogkalu/comic-text-and-bubble-detector` (bubble, text_bubble, text_free). Change **model_id** for other HF object-detection models; use **score_threshold** and **labels_include** (comma-separated) to filter. |
+| **mmocr_det** | **External dependency heavy** | `pip install openmim` then `mim install mmengine mmcv mmdet mmocr` (see `doc/INSTALL_MMOCR.md` for Windows). | Select **mmocr_det**; pair with mmocr_ocr. |
+| **paddle_det_v5** | **Beta** | `pip install paddlepaddle paddleocr` (3.x). | Select **paddle_det_v5**; pair with paddle_rec_v5. |
+| **surya_det** | **Beta** | `pip install surya-ocr` | Select **surya_det**; pair with surya_ocr. |
+| **magi_det** | **Beta** | `pip install transformers torch einops` | Select **magi_det**; model downloads from HF (ragavsachdeva/magi) on first use; pair with any OCR. |
+| **craft_det** | **External dependency heavy** | `pip install craft-text-detector torch` | Select **craft_det**; outputs 4-point quads for merge; pair with any OCR. **Conflict:** needs opencv<4.5.4.62; see [Optional dependencies](#8-optional-dependency-conflicts-and-workarounds). |
+| **rapidocr_det** | **Beta** | `pip install rapidocr-onnxruntime` | Select **rapidocr_det**; lightweight ONNX detection; pair with **rapidocr** OCR for EasyScanlate-like pipeline. Optional models in `data/models/rapidocr/`. See docs/OPTIONAL_DEPENDENCIES.md. |
+| **dptext_detr** | **External dependency heavy** | Clone [DPText-DETR](https://github.com/ymy-k/DPText-DETR), install its deps. | Select **dptext_detr**; set **repo_path** to your clone; pair with any OCR. |
+| **swintextspotter_v2** | **External dependency heavy** | Clone [SwinTextSpotterv2](https://github.com/mxin262/SwinTextSpotterv2), install its deps. | Select **swintextspotter_v2**; set **repo_path**; use **none_ocr** if demo outputs text. |
+| **hunyuan_ocr_det** | **Experimental** | Same as hunyuan_ocr (transformers, etc.). | Select **hunyuan_ocr_det**; set OCR to **none_ocr** to keep spotter text. |
+| **textmamba_det** | **Experimental** | None (stub) | Selecting it raises an error until official code is released; use mmocr_det or surya_det meanwhile. |
 
 ---
 
@@ -739,41 +752,41 @@ Select the OCR from the **OCR** dropdown. Install only the dependencies for the 
 
 ### Original / built-in
 
-| Module | How to run |
-|--------|-------------|
-| **paddle_ocr** | Paddle stack; select and set language, device. Pair with paddle_det. |
-| **manga_ocr** | Select **manga_ocr**; model in `data/models/manga-ocr-base` (auto-download). |
-| **easyocr_ocr**, **mmocr_ocr** | Pair with corresponding detector. |
-| **mit32px**, **mit48px**, **mit48px_ctc** | From manga-image-translator; select as needed. |
-| **google_vision**, **bing_ocr**, **one_ocr**, **windows_ocr**, **macos_ocr**, **llm_ocr**, **stariver_ocr**, **none_ocr** | Select and configure (API keys, etc.). **llm_ocr** with provider **OpenRouter** offers free vision models in the dropdown (e.g. `openrouter/free`, Gemma/Gemini/Qwen VL). **none_ocr** = no OCR (use with spotters). |
+| Module | Tier | How to run |
+|--------|------|-------------|
+| **paddle_ocr** | **Stable** | Paddle stack; select and set language, device. Pair with paddle_det. |
+| **manga_ocr** | **Stable** | Select **manga_ocr**; model in `data/models/manga-ocr-base` (auto-download). |
+| **easyocr_ocr**, **mmocr_ocr** | **Beta / External dependency heavy** | Pair with corresponding detector. |
+| **mit32px**, **mit48px**, **mit48px_ctc** | **Stable** | From manga-image-translator; select as needed. |
+| **google_vision**, **bing_ocr**, **one_ocr**, **windows_ocr**, **macos_ocr**, **llm_ocr**, **stariver_ocr**, **none_ocr** | **Mixed (API/platform/none)** | Select and configure (API keys, etc.). **llm_ocr** with provider **OpenRouter** offers free vision models in the dropdown (e.g. `openrouter/free`, Gemma/Gemini/Qwen VL). **none_ocr** = no OCR (use with spotters). |
 
 ### New in this fork
 
-| Module | Dependencies | How to run |
-|--------|--------------|------------|
-| **paddle_rec_v5** | `pip install paddlepaddle paddleocr` (3.x). | PP-OCRv5 recognition; pair with paddle_det_v5. Select and set language, device. |
-| **rapidocr** | `pip install rapidocr-onnxruntime` | Select **rapidocr**; lightweight ONNX recognition; pair with **rapidocr_det** for EasyScanlate-like pipeline. Optional rec/dict in `data/models/rapidocr/`. See docs/OPTIONAL_DEPENDENCIES.md. |
-| **PaddleOCRVLManga**, **paddle_vl** | PaddleOCR-VL (manga or local server). | VLM manga or server; select and configure. |
-| **paddleocr_vl_hf** | `transformers` 5.x | Select **paddleocr_vl_hf**; use prompt "OCR:"; 109 languages, SOTA document. |
-| **surya_ocr** | `pip install surya-ocr` | Select **surya_ocr**; set language (e.g. Chinese (Simplified)), **Fix Latin misread** True for CJK; crop_padding 6–8. |
-| **trocr** | `transformers`, `torch`, `PIL` | Select **trocr**; good for printed/handwritten English. |
-| **got_ocr2** | `transformers`, `torch` | Select **got_ocr2**; unified OCR, tables/formulas. |
-| **glm_ocr** | `transformers` (e.g. 5.x) | Select **glm_ocr**; 0.9B document. |
-| **donut** | `transformers`, `torch` | Select **donut**; DocVQA/CORD task prompts. |
-| **qwen2vl_7b** | `transformers`, `torch`, `accelerate` | Select **qwen2vl_7b**; ~16GB+ VRAM. |
-| **deepseek_ocr** | `transformers`, `trust_remote_code` | Select **deepseek_ocr**; document, layout. |
-| **lighton_ocr** | `transformers`, `torch` | Select **lighton_ocr**; 1B, strong per-parameter. |
-| **chandra_ocr** | `pip install chandra-ocr` | Select **chandra_ocr**; 9B, layout/tables. |
-| **docowl2_ocr** | `transformers`, `trust_remote_code` | Select **docowl2_ocr**; document understanding. |
-| **nanonets_ocr** | `transformers`, `torch` | Select **nanonets_ocr**; 3B VLM, chat-style. |
-| **ocean_ocr** | `transformers`, `torch`, `einops` | Select **ocean_ocr**; 3B MLLM, quality-focused. |
-| **internvl2_ocr**, **internvl3_ocr** | `transformers`, `torch` | Select and choose model size (2B/8B etc.); trust_remote_code. |
-| **hunyuan_ocr** | `transformers`, `torch` (see HunyuanOCR repo) | Select **hunyuan_ocr**; SOTA <3B class. |
-| **florence2_ocr** | `transformers`, `torch` | Select **florence2_ocr**; Microsoft vision, base/large. |
-| **minicpm_ocr** | `transformers`, `torch` | Select **minicpm_ocr**; compact VLM. |
-| **ocrflux** | `transformers`, `torch` | Select **ocrflux**; document OCR. |
-| **manga_ocr_mobile** | `pip install tflite-runtime huggingface_hub transformers` (optional) | Select **manga_ocr_mobile**; TFLite Japanese manga; lighter than manga_ocr. |
-| **nemotron_ocr** | `transformers`, `accelerate`, `torch`, `albumentations`, `timm`; postprocessing from HF repo. | Select **nemotron_ocr**; full-page document parsing; assigns text to blocks by bbox overlap; set **min_resolution** (e.g. 1024), **iou_threshold**. |
+| Module | Tier | Dependencies | How to run |
+|--------|------|--------------|------------|
+| **paddle_rec_v5** | **Beta** | `pip install paddlepaddle paddleocr` (3.x). | PP-OCRv5 recognition; pair with paddle_det_v5. Select and set language, device. |
+| **rapidocr** | **Beta** | `pip install rapidocr-onnxruntime` | Select **rapidocr**; lightweight ONNX recognition; pair with **rapidocr_det** for EasyScanlate-like pipeline. Optional rec/dict in `data/models/rapidocr/`. See docs/OPTIONAL_DEPENDENCIES.md. |
+| **PaddleOCRVLManga**, **paddle_vl** | **External dependency heavy** | PaddleOCR-VL (manga or local server). | VLM manga or server; select and configure. |
+| **paddleocr_vl_hf** | **External dependency heavy** | `transformers` 5.x | Select **paddleocr_vl_hf**; use prompt "OCR:"; 109 languages, SOTA document. |
+| **surya_ocr** | **Beta** | `pip install surya-ocr` | Select **surya_ocr**; set language (e.g. Chinese (Simplified)), **Fix Latin misread** True for CJK; crop_padding 6–8. |
+| **trocr** | **Beta** | `transformers`, `torch`, `PIL` | Select **trocr**; good for printed/handwritten English. |
+| **got_ocr2** | **External dependency heavy** | `transformers`, `torch` | Select **got_ocr2**; unified OCR, tables/formulas. |
+| **glm_ocr** | **External dependency heavy** | `transformers` (e.g. 5.x) | Select **glm_ocr**; 0.9B document. |
+| **donut** | **External dependency heavy** | `transformers`, `torch` | Select **donut**; DocVQA/CORD task prompts. |
+| **qwen2vl_7b** | **External dependency heavy** | `transformers`, `torch`, `accelerate` | Select **qwen2vl_7b**; ~16GB+ VRAM. |
+| **deepseek_ocr** | **External dependency heavy** | `transformers`, `trust_remote_code` | Select **deepseek_ocr**; document, layout. |
+| **lighton_ocr** | **External dependency heavy** | `transformers`, `torch` | Select **lighton_ocr**; 1B, strong per-parameter. |
+| **chandra_ocr** | **External dependency heavy** | `pip install chandra-ocr` | Select **chandra_ocr**; 9B, layout/tables. |
+| **docowl2_ocr** | **External dependency heavy** | `transformers`, `trust_remote_code` | Select **docowl2_ocr**; document understanding. |
+| **nanonets_ocr** | **External dependency heavy** | `transformers`, `torch` | Select **nanonets_ocr**; 3B VLM, chat-style. |
+| **ocean_ocr** | **External dependency heavy** | `transformers`, `torch`, `einops` | Select **ocean_ocr**; 3B MLLM, quality-focused. |
+| **internvl2_ocr**, **internvl3_ocr** | **External dependency heavy** | `transformers`, `torch` | Select and choose model size (2B/8B etc.); trust_remote_code. |
+| **hunyuan_ocr** | **External dependency heavy** | `transformers`, `torch` (see HunyuanOCR repo) | Select **hunyuan_ocr**; SOTA <3B class. |
+| **florence2_ocr** | **External dependency heavy** | `transformers`, `torch` | Select **florence2_ocr**; Microsoft vision, base/large. |
+| **minicpm_ocr** | **External dependency heavy** | `transformers`, `torch` | Select **minicpm_ocr**; compact VLM. |
+| **ocrflux** | **External dependency heavy** | `transformers`, `torch` | Select **ocrflux**; document OCR. |
+| **manga_ocr_mobile** | **Beta** | `pip install tflite-runtime huggingface_hub transformers` (optional) | Select **manga_ocr_mobile**; TFLite Japanese manga; lighter than manga_ocr. |
+| **nemotron_ocr** | **External dependency heavy** | `transformers`, `accelerate`, `torch`, `albumentations`, `timm`; postprocessing from HF repo. | Select **nemotron_ocr**; full-page document parsing; assigns text to blocks by bbox overlap; set **min_resolution** (e.g. 1024), **iou_threshold**. |
 
 ---
 

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -6,6 +6,17 @@
 
 ---
 
+## 模块分级与兼容矩阵
+
+| 分级 | 含义 |
+|---|---|
+| **Stable** | 默认与首跑预设优先使用，验证最充分。 |
+| **Beta** | 大多数场景可用，但跨环境验证少于 Stable。 |
+| **Experimental** | 新功能/占位实现/高波动模块。 |
+| **External dependency heavy** | 依赖较重（大模型、额外仓库或外部服务）。 |
+
+统一兼容矩阵请见：**[docs/MODULE_COMPATIBILITY_MATRIX.md](docs/MODULE_COMPATIBILITY_MATRIX.md)**。
+
 ## 简介
 
 | 项目 | 说明 |
@@ -60,11 +71,11 @@
 
 ## 国漫 / 简体中文推荐设置
 
-| 阶段 | 推荐 | 关键设置 |
-|------|------|----------|
-| **检测** | CTD | detect_size 1280，box score 0.42–0.48，box_padding 4–6 |
-| **OCR** | Surya OCR | 语言：简体中文，Fix Latin misread：True，crop_padding 6–8 |
-| **修复** | lama_large_512px | mask_dilation 1–2，inpaint_size 1024 |
+| 阶段 | 推荐 | 分级 | 关键设置 |
+|------|------|------|----------|
+| **检测** | CTD | **Stable** | detect_size 1280，box score 0.42–0.48，box_padding 4–6 |
+| **OCR** | Surya OCR | **Beta** | 语言：简体中文，Fix Latin misread：True，crop_padding 6–8 |
+| **修复** | lama_large_512px | **Beta** | mask_dilation 1–2，inpaint_size 1024 |
 
 更多质量分级与设置见 [docs/MANHUA_BEST_SETTINGS.md](docs/MANHUA_BEST_SETTINGS.md)、[docs/QUALITY_RANKINGS.md](docs/QUALITY_RANKINGS.md)。
 

--- a/docs/MODELS_REFERENCE.md
+++ b/docs/MODELS_REFERENCE.md
@@ -3,6 +3,7 @@
 This document maps the **curated list of 20+ models per category** (from community recommendations) to **what BallonsTranslator already supports** and what is optional or potential. Use it to choose modules and plan integrations.
 
 **Target:** Windows + NVIDIA GPU. VRAM notes are approximate. For **quality/accuracy rankings** (best to worst) of all detection, OCR, and translation modules, see **[docs/QUALITY_RANKINGS.md](QUALITY_RANKINGS.md)**.
+For tier labels (Stable/Beta/Experimental/External dependency heavy) and cross-platform compatibility, use the canonical matrix: **[docs/MODULE_COMPATIBILITY_MATRIX.md](MODULE_COMPATIBILITY_MATRIX.md)**.
 
 ---
 

--- a/docs/MODULE_COMPATIBILITY_MATRIX.md
+++ b/docs/MODULE_COMPATIBILITY_MATRIX.md
@@ -1,0 +1,47 @@
+# Module compatibility matrix (canonical)
+
+This is the canonical compatibility matrix for module readiness and environment cost.
+
+## Tier definitions
+
+| Tier | Meaning | Typical use |
+|---|---|---|
+| **Stable** | Widely used in this project defaults and core workflows. | Best first choice for first-run and production. |
+| **Beta** | Works for many users but has narrower validation or more variance. | Use when Stable misses edge cases. |
+| **Experimental** | New/stub/rapidly changing behavior. | Testing and niche workflows. |
+| **External dependency heavy** | Requires large/complex optional stacks or external repos/APIs. | Advanced users who accept setup overhead. |
+
+## Core first-run presets (prioritized)
+
+These are prioritized on first run because they are Stable in this fork:
+
+| Stage | Default module | Tier |
+|---|---|---|
+| Text detection | `ctd` | Stable |
+| OCR | `manga_ocr` | Stable |
+| Inpainting | `aot` | Stable |
+| Translation | `google` | Stable |
+
+## Quick compatibility matrix
+
+| Category | Module | Tier | Windows | Linux | macOS | CPU | CUDA |
+|---|---|---|---|---|---|---|---|
+| Detector | `ctd` | Stable | ✅ | ✅ | ⚠️ | ✅ | ✅ |
+| Detector | `paddle_det` | Stable | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Detector | `mmocr_det` | External dependency heavy | ⚠️ | ✅ | ⚠️ | ✅ | ✅ |
+| Detector | `dptext_detr` | External dependency heavy | ⚠️ | ✅ | ⚠️ | ⚠️ | ✅ |
+| OCR | `manga_ocr` | Stable | ✅ | ✅ | ✅ | ✅ | ✅ |
+| OCR | `surya_ocr` | Beta | ✅ | ✅ | ✅ | ✅ | ✅ |
+| OCR | `paddleocr_vl_hf` | External dependency heavy | ⚠️ | ✅ | ⚠️ | ⚠️ | ✅ |
+| OCR | `hunyuan_ocr` | External dependency heavy | ⚠️ | ✅ | ⚠️ | ⚠️ | ✅ |
+| Inpaint | `aot` | Stable | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Inpaint | `lama_large_512px` | Beta | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Inpaint | `mat` | External dependency heavy | ⚠️ | ✅ | ⚠️ | ⚠️ | ✅ |
+| Translator | `google` | Stable | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Translator | `LLM_API_Translator` | Beta | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Translator | `text-generation-webui` | Experimental | ⚠️ | ✅ | ⚠️ | ✅ | ✅ |
+
+Notes:
+- `⚠️` means "possible, but usually needs extra setup or has less validation in community reports."
+- For full quality ranking by task, see `docs/QUALITY_RANKINGS.md`.
+- For module-to-model mapping, see `docs/MODELS_REFERENCE.md`.

--- a/docs/QUALITY_RANKINGS.md
+++ b/docs/QUALITY_RANKINGS.md
@@ -1,6 +1,7 @@
 # Quality & Accuracy Rankings: Detection, OCR, Translation
 
 **Criteria:** Quality and accuracy only. Speed is ignored. This document ranks every text detection, OCR, and translation model/implementation in BallonsTranslator. Where benchmarks show **performance clusters** rather than clear 1→N separation, **tier-based rankings** are used instead of strict linear order, so the list is easier to defend against published benchmarks and community consensus (see sanity-check notes below).
+For operational stability tiers used by UI/docs (**Stable / Beta / Experimental / External dependency heavy**), see **[docs/MODULE_COMPATIBILITY_MATRIX.md](MODULE_COMPATIBILITY_MATRIX.md)**.
 
 **Scope:** Detection → finding text regions (boxes/masks). OCR → recognizing text inside regions. Translation → converting source text to target language. Inpainting is out of scope here; see the [Diffusion vs non-diffusion](#4-diffusion-vs-non-diffusion-note) note for how diffusion-based inpainting compares for text removal.
 

--- a/ui/configpanel.py
+++ b/ui/configpanel.py
@@ -480,6 +480,12 @@ class ConfigPanel(Widget):
         )
         dlConfigPanel.vlayout.addWidget(ocr_auto_sublock)
         self.ocr_auto_by_language_checker.stateChanged.connect(self._on_ocr_auto_by_language_changed)
+        self.show_module_tier_badges_checker, tier_sublock = checkbox_with_label(
+            self.tr('Show module tier badge in selector tooltip'),
+            discription=self.tr('Show Stable/Beta/Experimental/External-heavy badge in detector/OCR/inpainter/translator dropdown tooltips.')
+        )
+        dlConfigPanel.vlayout.addWidget(tier_sublock)
+        self.show_module_tier_badges_checker.stateChanged.connect(self._on_show_module_tier_badges_changed)
         self.merge_nearby_blocks_checker, merge_sublock = checkbox_with_label(
             self.tr('Merge nearby blocks (collision)'),
             discription=self.tr('Merge detection boxes that are close (collision-based). Use when OCR returns many small boxes.')
@@ -1177,6 +1183,9 @@ class ConfigPanel(Widget):
     def _on_skip_already_translated_changed(self):
         pcfg.module.skip_already_translated = self.skip_already_translated_checker.isChecked()
 
+    def _on_show_module_tier_badges_changed(self):
+        pcfg.show_module_tier_badges_in_tooltips = self.show_module_tier_badges_checker.isChecked()
+
     def _on_merge_nearby_blocks_changed(self):
         pcfg.module.merge_nearby_blocks_collision = self.merge_nearby_blocks_checker.isChecked()
 
@@ -1719,6 +1728,8 @@ class ConfigPanel(Widget):
             self.ocr_cache_enabled_checker.setChecked(getattr(pcfg.module, 'ocr_cache_enabled', True))
         if hasattr(self, 'ocr_auto_by_language_checker'):
             self.ocr_auto_by_language_checker.setChecked(getattr(pcfg.module, 'ocr_auto_by_language', False))
+        if hasattr(self, 'show_module_tier_badges_checker'):
+            self.show_module_tier_badges_checker.setChecked(getattr(pcfg, 'show_module_tier_badges_in_tooltips', True))
         if hasattr(self, 'skip_already_translated_checker'):
             self.skip_already_translated_checker.setChecked(getattr(pcfg.module, 'skip_already_translated', False))
         if hasattr(self, 'merge_nearby_blocks_checker'):

--- a/ui/model_package_selector_dialog.py
+++ b/ui/model_package_selector_dialog.py
@@ -19,7 +19,7 @@ from qtpy.QtWidgets import (
     QFrame,
 )
 
-from utils.model_packages import MODEL_PACKAGES, PACKAGE_LABELS
+from utils.model_packages import MODEL_PACKAGES, PACKAGE_LABELS, PACKAGE_TIERS
 
 
 class ModelPackageSelectorDialog(QDialog):
@@ -46,7 +46,12 @@ class ModelPackageSelectorDialog(QDialog):
 
         group = QGroupBox(self.tr("Model packages"))
         group_layout = QVBoxLayout(group)
-        for package_id in MODEL_PACKAGES:
+        tier_order = {"Stable": 0, "Beta": 1, "Experimental": 2, "External dependency heavy": 3}
+        sorted_package_ids = sorted(
+            MODEL_PACKAGES.keys(),
+            key=lambda pid: (tier_order.get(PACKAGE_TIERS.get(pid, "Stable"), 99), pid),
+        )
+        for package_id in sorted_package_ids:
             label, desc = PACKAGE_LABELS.get(package_id, (package_id, ""))
             cb = QCheckBox(self.tr(label))
             cb.setToolTip(self.tr(desc))

--- a/ui/module_parse_widgets.py
+++ b/ui/module_parse_widgets.py
@@ -8,6 +8,7 @@ from .custom_widget import ConfigComboBox, ParamComboBox, NoBorderPushBtn, Param
 from .custom_widget.hover_animation import install_hover_opacity_animation, install_hover_scale_animation
 from utils.shared import CONFIG_COMBOBOX_LONG, size2width, CONFIG_COMBOBOX_SHORT, CONFIG_COMBOBOX_HEIGHT
 from utils.config import pcfg
+from utils.module_tiers import format_module_tier_tooltip
 
 from qtpy.QtWidgets import QPlainTextEdit, QHBoxLayout, QVBoxLayout, QWidget, QLabel, QCheckBox, QLineEdit, QGridLayout, QPushButton, QMessageBox, QSpinBox
 from qtpy.QtCore import Qt, Signal, QTimer
@@ -353,6 +354,16 @@ class ModuleConfigParseWidget(QWidget):
                 continue
 
             self.module_combobox.addItem(module)
+            tip = format_module_tier_tooltip(
+                module,
+                show_badge=bool(getattr(pcfg, "show_module_tier_badges_in_tooltips", True)),
+            )
+            if tip:
+                self.module_combobox.setItemData(
+                    self.module_combobox.count() - 1,
+                    tip,
+                    Qt.ItemDataRole.ToolTipRole,
+                )
             params = module_dict[module]
             if params is not None:
                 self.param_widget_map[module] = None

--- a/utils/config.py
+++ b/utils/config.py
@@ -490,6 +490,8 @@ class ProgramConfig(Config):
     manga_source_translate_raw_search: bool = True  # For raw sources: translate search query to Japanese/Korean/Chinese
     # Model packages to download at startup (None = legacy "all"; ["core"] = minimal). See utils.model_packages.
     model_packages_enabled: Optional[List[str]] = field(default_factory=lambda: ["core"])
+    # When True, module dropdown tooltips show tier badges (Stable/Beta/Experimental/External-heavy).
+    show_module_tier_badges_in_tooltips: bool = True
     # When True, show all modules in detector/OCR/translator dropdowns (including not downloaded or incompatible). When False, only show ready modules.
     dev_mode: bool = False
     # Temporary: when enabled, emit structured diagnostic logs for UI actions and pipeline stage transitions.
@@ -609,6 +611,7 @@ CONFIG_KEY_ORDER = (
     "manga_source_request_delay", "manga_source_open_after_download", "manga_source_playwright_headless",
     "manga_source_translate_raw_search",
     "model_packages_enabled",
+    "show_module_tier_badges_in_tooltips",
     "dev_mode",
     "diagnostic_mode",
     "release_caches_after_batch", "manual_mode", "skip_ignored_in_run",

--- a/utils/model_packages.py
+++ b/utils/model_packages.py
@@ -36,12 +36,20 @@ MODEL_PACKAGES = {
     ],
 }
 
+# Package tier controls first-run presentation order and labels.
+PACKAGE_TIERS = {
+    "core": "Stable",
+    "advanced_inpaint": "Beta",
+    "advanced_ocr": "External dependency heavy",
+    "optional_onnx": "Experimental",
+}
+
 # Human-readable labels and short descriptions for the first-launch dialog
 PACKAGE_LABELS = {
-    "core": ("Core (recommended)", "Text detection, inpainting, OCR, pkuseg — minimal to run"),
-    "advanced_ocr": ("Advanced OCR", "PaddleOCR-VL for manga (~1.7 GB), MIT 48px/32px"),
-    "advanced_inpaint": ("Advanced inpainting", "LaMa variants, ONNX, PatchMatch"),
-    "optional_onnx": ("Optional ONNX inpainting", "Lama 2025 / lama-manga ONNX (smaller, CPU-friendly)"),
+    "core": ("Core (recommended) [Stable]", "Text detection, inpainting, OCR, pkuseg — minimal to run"),
+    "advanced_ocr": ("Advanced OCR [External dependency heavy]", "PaddleOCR-VL for manga (~1.7 GB), MIT 48px/32px"),
+    "advanced_inpaint": ("Advanced inpainting [Beta]", "LaMa variants, ONNX, PatchMatch"),
+    "optional_onnx": ("Optional ONNX inpainting [Experimental]", "Lama 2025 / lama-manga ONNX (smaller, CPU-friendly)"),
 }
 
 

--- a/utils/module_tiers.py
+++ b/utils/module_tiers.py
@@ -1,0 +1,101 @@
+"""
+Tier metadata for module stability and dependency weight.
+
+Used by docs/UI to show consistent labels:
+- Stable
+- Beta
+- Experimental
+- External dependency heavy
+"""
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+TIER_STABLE = "Stable"
+TIER_BETA = "Beta"
+TIER_EXPERIMENTAL = "Experimental"
+TIER_EXTERNAL_HEAVY = "External dependency heavy"
+
+TIER_BADGES = {
+    TIER_STABLE: "🟢 Stable",
+    TIER_BETA: "🟡 Beta",
+    TIER_EXPERIMENTAL: "🟠 Experimental",
+    TIER_EXTERNAL_HEAVY: "🔵 External dependency heavy",
+}
+
+# Canonical per-module labels used by UI tooltips and docs.
+# Missing modules default to Stable in UI.
+MODULE_TIERS: Dict[str, str] = {
+    # Detectors
+    "ctd": TIER_STABLE,
+    "paddle_det": TIER_STABLE,
+    "easyocr_det": TIER_BETA,
+    "ysgyolo": TIER_BETA,
+    "hf_object_det": TIER_BETA,
+    "mmocr_det": TIER_EXTERNAL_HEAVY,
+    "surya_det": TIER_BETA,
+    "paddle_det_v5": TIER_BETA,
+    "magi_det": TIER_BETA,
+    "craft_det": TIER_EXTERNAL_HEAVY,
+    "rapidocr_det": TIER_BETA,
+    "dptext_detr": TIER_EXTERNAL_HEAVY,
+    "swintextspotter_v2": TIER_EXTERNAL_HEAVY,
+    "hunyuan_ocr_det": TIER_EXPERIMENTAL,
+    "textmamba_det": TIER_EXPERIMENTAL,
+    # OCR
+    "manga_ocr": TIER_STABLE,
+    "paddle_ocr": TIER_STABLE,
+    "mit48px_ctc": TIER_STABLE,
+    "mit48px": TIER_BETA,
+    "mit32px": TIER_BETA,
+    "easyocr_ocr": TIER_BETA,
+    "mmocr_ocr": TIER_EXTERNAL_HEAVY,
+    "surya_ocr": TIER_BETA,
+    "paddle_rec_v5": TIER_BETA,
+    "rapidocr": TIER_BETA,
+    "PaddleOCRVLManga": TIER_EXTERNAL_HEAVY,
+    "paddle_vl": TIER_EXTERNAL_HEAVY,
+    "paddleocr_vl_hf": TIER_EXTERNAL_HEAVY,
+    "qwen2vl_7b": TIER_EXTERNAL_HEAVY,
+    "internvl2_ocr": TIER_EXTERNAL_HEAVY,
+    "internvl3_ocr": TIER_EXTERNAL_HEAVY,
+    "nemotron_ocr": TIER_EXTERNAL_HEAVY,
+    "hunyuan_ocr": TIER_EXTERNAL_HEAVY,
+    "manga_ocr_mobile": TIER_BETA,
+    # Inpainters
+    "aot": TIER_STABLE,
+    "lama_large_512px": TIER_BETA,
+    "lama_mpe": TIER_BETA,
+    "lama_onnx": TIER_BETA,
+    "lama_manga_onnx": TIER_BETA,
+    "patchmatch": TIER_STABLE,
+    "simple_lama": TIER_EXTERNAL_HEAVY,
+    "mat": TIER_EXTERNAL_HEAVY,
+    "flux_fill": TIER_EXTERNAL_HEAVY,
+    # Translators
+    "google": TIER_STABLE,
+    "DeepL": TIER_STABLE,
+    "ChatGPT": TIER_BETA,
+    "LLM_API_Translator": TIER_BETA,
+    "Sakura": TIER_BETA,
+    "nllb200": TIER_BETA,
+    "m2m100": TIER_BETA,
+    "text-generation-webui": TIER_EXPERIMENTAL,
+}
+
+
+def get_module_tier(module_key: str) -> str:
+    return MODULE_TIERS.get(module_key, TIER_STABLE)
+
+
+def get_module_tier_badge(module_key: str) -> str:
+    return TIER_BADGES.get(get_module_tier(module_key), TIER_BADGES[TIER_STABLE])
+
+
+def format_module_tier_tooltip(module_key: str, *, show_badge: bool = True) -> Optional[str]:
+    if not show_badge:
+        return None
+    tier = get_module_tier(module_key)
+    badge = TIER_BADGES.get(tier, tier)
+    return f"{module_key} — {badge}"
+


### PR DESCRIPTION
### Motivation

- Provide a simple, consistent stability/weighting system for modules so docs and the UI can guide users (Stable / Beta / Experimental / External dependency heavy). 
- Surface tier information in module selectors and READMEs so first-run choices and everyday module selection favor well-tested modules. 
- Ship one canonical compatibility matrix in `docs/` and link it from English/Chinese READMEs to avoid duplicated, out-of-date guidance.

### Description

- Added a new helper `utils/module_tiers.py` that defines canonical tiers, human-friendly badges, and helpers: `get_module_tier`, `get_module_tier_badge`, and `format_module_tier_tooltip`.
- Exposed optional tooltip badges in UI module selectors by wiring `format_module_tier_tooltip` into `ui/module_parse_widgets.py` so combobox items show tier badges when enabled.
- Added a persisted config flag `show_module_tier_badges_in_tooltips` to `ProgramConfig` (`utils/config.py`) and a toggle in the Config panel (`ui/configpanel.py`) to enable/disable the item-tooltips.
- Prioritized Stable packages in the first-run model-package selector by adding `PACKAGE_TIERS` and annotated `PACKAGE_LABELS` in `utils/model_packages.py`, and sorting the package list in `ui/model_package_selector_dialog.py` so Stable packages appear first.
- Created a canonical doc `docs/MODULE_COMPATIBILITY_MATRIX.md` with tier definitions, stable-first defaults and a quick compatibility matrix, and linked this file from `README.md`, `README_zh_CN.md`, `docs/MODELS_REFERENCE.md`, and `docs/QUALITY_RANKINGS.md` while adding tier labels to README model tables.
- Minor glue: added config save/load wiring for the new flag, and small UI text/tooltip updates for the package selector and Config panel.

Files changed/added (high level): `utils/module_tiers.py` (new), `utils/config.py` (new config key), `utils/model_packages.py` (package-tier metadata), `ui/module_parse_widgets.py` (tooltip injection), `ui/configpanel.py` (toggle), `ui/model_package_selector_dialog.py` (sorted), `docs/MODULE_COMPATIBILITY_MATRIX.md` (new), `README.md`, `README_zh_CN.md`, `docs/MODELS_REFERENCE.md`, `docs/QUALITY_RANKINGS.md` (links/labels).

### Testing

- Ran the Python compile check: `python -m compileall -f -q utils/module_tiers.py utils/config.py ui/module_parse_widgets.py ui/configpanel.py ui/model_package_selector_dialog.py` and it completed without errors.
- Performed a quick smoke import/inspection: ran a small script to call `format_module_tier_tooltip('ctd', show_badge=True)` and inspect `PACKAGE_TIERS` / `PACKAGE_LABELS`; the script printed the expected badge and package label (`ctd — 🟢 Stable` and `Stable Core (recommended) [Stable]`).

All automated checks executed in this rollout succeeded. No runtime pipeline or UI integration tests were run beyond the compile and smoke checks listed above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f02fd0bec0832cadb2e35bec79805e)