### PR TITLE
Add pytest coverage for model package selection, config defaults, and launcher command snapshots

### DIFF
--- a/tests/test_config_model_packages_defaulting.py
+++ b/tests/test_config_model_packages_defaulting.py
@@ -1,0 +1,79 @@
+import json
+import sys
+import types
+
+# utils.config -> utils.io_utils imports cv2; provide/patch a minimal stub for test envs without libGL.
+cv2_stub = sys.modules.get("cv2") or types.ModuleType("cv2")
+cv2_stub.IMREAD_COLOR = getattr(cv2_stub, "IMREAD_COLOR", 1)
+cv2_stub.IMREAD_GRAYSCALE = getattr(cv2_stub, "IMREAD_GRAYSCALE", 0)
+cv2_stub.COLOR_GRAY2RGB = getattr(cv2_stub, "COLOR_GRAY2RGB", 0)
+cv2_stub.COLOR_RGB2BGR = getattr(cv2_stub, "COLOR_RGB2BGR", 0)
+cv2_stub.COLOR_RGBA2BGRA = getattr(cv2_stub, "COLOR_RGBA2BGRA", 0)
+cv2_stub.IMWRITE_JPEG_QUALITY = getattr(cv2_stub, "IMWRITE_JPEG_QUALITY", 1)
+cv2_stub.IMWRITE_WEBP_QUALITY = getattr(cv2_stub, "IMWRITE_WEBP_QUALITY", 64)
+cv2_stub.cvtColor = getattr(cv2_stub, "cvtColor", lambda img, code: img)
+cv2_stub.imencode = getattr(
+    cv2_stub,
+    "imencode",
+    lambda ext, img, enc: (True, types.SimpleNamespace(tofile=lambda p: None)),
+)
+cv2_stub.imshow = getattr(cv2_stub, "imshow", lambda *args, **kwargs: None)
+cv2_stub.waitKey = getattr(cv2_stub, "waitKey", lambda *args, **kwargs: 0)
+sys.modules["cv2"] = cv2_stub
+
+from utils.config import ProgramConfig
+
+
+def _write_config(path, data):
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+
+def test_model_packages_enabled_defaults_to_core_when_missing(tmp_path):
+    cfg_path = tmp_path / "config.json"
+    _write_config(
+        cfg_path,
+        {
+            "module": {
+                "translator": "google",
+                "translator_params": {},
+            }
+        },
+    )
+
+    loaded = ProgramConfig.load(str(cfg_path))
+    assert loaded.model_packages_enabled == ["core"]
+
+
+def test_model_packages_enabled_defaults_to_core_when_null(tmp_path):
+    cfg_path = tmp_path / "config.json"
+    _write_config(
+        cfg_path,
+        {
+            "model_packages_enabled": None,
+            "module": {
+                "translator": "google",
+                "translator_params": {},
+            },
+        },
+    )
+
+    loaded = ProgramConfig.load(str(cfg_path))
+    assert loaded.model_packages_enabled == ["core"]
+
+
+def test_model_packages_enabled_preserves_explicit_value(tmp_path):
+    cfg_path = tmp_path / "config.json"
+    expected = ["core", "advanced_ocr"]
+    _write_config(
+        cfg_path,
+        {
+            "model_packages_enabled": expected,
+            "module": {
+                "translator": "google",
+                "translator_params": {},
+            },
+        },
+    )
+
+    loaded = ProgramConfig.load(str(cfg_path))
+    assert loaded.model_packages_enabled == expected

--- a/tests/test_model_packages.py
+++ b/tests/test_model_packages.py
@@ -1,0 +1,70 @@
+import types
+
+from utils.model_packages import get_module_classes_for_packages
+
+
+def _mk_cls(name: str, has_download: bool = True):
+    attrs = {"__name__": name}
+    attrs["download_file_list"] = ["weights.bin"] if has_download else None
+    return types.SimpleNamespace(**attrs)
+
+
+def test_selected_packages_map_to_expected_module_classes():
+    ctd = _mk_cls("CTD")
+    aot = _mk_cls("AOT")
+    manga_ocr = _mk_cls("MangaOCR")
+    paddle_vl = _mk_cls("PaddleOCRVLManga")
+
+    registries = {
+        "textdetector": {"ctd": ctd},
+        "inpaint": {"aot": aot},
+        "ocr": {
+            "manga_ocr": manga_ocr,
+            "PaddleOCRVLManga": paddle_vl,
+            # This entry exists but should be skipped because it has no download files.
+            "mit48px_ctc": _mk_cls("MIT48CTC", has_download=False),
+        },
+        "translator": {},
+    }
+
+    selected = ["core", "advanced_ocr"]
+    classes = get_module_classes_for_packages(selected, registries=registries)
+
+    assert classes == [ctd, aot, manga_ocr, paddle_vl]
+
+
+def test_empty_selection_returns_no_modules():
+    assert get_module_classes_for_packages([], registries={}) == []
+
+
+def test_unknown_package_ids_are_ignored():
+    ctd = _mk_cls("CTD")
+    registries = {
+        "textdetector": {"ctd": ctd},
+        "inpaint": {},
+        "ocr": {},
+        "translator": {},
+    }
+
+    classes = get_module_classes_for_packages(["core", "does_not_exist"], registries=registries)
+    assert classes == [ctd]
+
+
+def test_no_core_selection_only_uses_selected_non_core_packages():
+    paddle_vl = _mk_cls("PaddleOCRVLManga")
+    mit48 = _mk_cls("MIT48")
+    mit32 = _mk_cls("MIT32")
+    registries = {
+        "textdetector": {"ctd": _mk_cls("CTD")},
+        "inpaint": {"aot": _mk_cls("AOT")},
+        "ocr": {
+            "PaddleOCRVLManga": paddle_vl,
+            "mit48px": mit48,
+            "mit32px": mit32,
+        },
+        "translator": {},
+    }
+
+    classes = get_module_classes_for_packages(["advanced_ocr"], registries=registries)
+
+    assert classes == [paddle_vl, mit48, mit32]

--- a/tests/test_reset_modules_core_defaults.py
+++ b/tests/test_reset_modules_core_defaults.py
@@ -1,0 +1,81 @@
+import ast
+import copy
+from pathlib import Path
+from types import SimpleNamespace
+
+
+def _load_reset_method_callable(fake_pcfg, fake_save_config):
+    src_path = Path("ui/mainwindow.py")
+    tree = ast.parse(src_path.read_text(encoding="utf-8"), filename=str(src_path))
+
+    reset_fn = None
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef) and node.name == "MainWindow":
+            for child in node.body:
+                if isinstance(child, ast.FunctionDef) and child.name == "_reset_modules_to_core_defaults":
+                    reset_fn = copy.deepcopy(child)
+                    break
+    assert reset_fn is not None, "_reset_modules_to_core_defaults not found"
+
+    mod = ast.Module(body=[reset_fn], type_ignores=[])
+    ast.fix_missing_locations(mod)
+    env = {
+        "pcfg": fake_pcfg,
+        "save_config": fake_save_config,
+    }
+    exec(compile(mod, str(src_path), "exec"), env)
+    return env["_reset_modules_to_core_defaults"]
+
+
+class _FallbackModuleManager:
+    """Simulates module_manager fallback behavior when requested core defaults are unavailable."""
+
+    def __init__(self):
+        self.calls = []
+
+    def setTextDetector(self, key):
+        self.calls.append(("textdetector", key))
+
+    def setOCR(self, key):
+        # Simulate fallback away from manga_ocr
+        self.calls.append(("ocr", "mit48px" if key == "manga_ocr" else key))
+
+    def setInpainter(self, key):
+        self.calls.append(("inpainter", key))
+
+    def setTranslator(self, key):
+        self.calls.append(("translator", key))
+
+
+
+def test_reset_modules_to_core_defaults_delegates_to_module_manager_for_fallbacks():
+    fake_pcfg = SimpleNamespace(module=SimpleNamespace(
+        textdetector="old_detector",
+        ocr="old_ocr",
+        inpainter="old_inpainter",
+        translator="old_translator",
+    ))
+    saved = {"count": 0}
+
+    def fake_save_config():
+        saved["count"] += 1
+
+    reset = _load_reset_method_callable(fake_pcfg, fake_save_config)
+
+    fake_self = SimpleNamespace(module_manager=_FallbackModuleManager())
+    reset(fake_self)
+
+    # Config is reset to core defaults first.
+    assert fake_pcfg.module.textdetector == "ctd"
+    assert fake_pcfg.module.ocr == "manga_ocr"
+    assert fake_pcfg.module.inpainter == "aot"
+    assert fake_pcfg.module.translator == "google"
+    assert saved["count"] == 1
+
+    # Runtime setter calls are delegated, allowing module_manager-level fallback behavior.
+    assert fake_self.module_manager.calls == [
+        ("textdetector", "ctd"),
+        ("ocr", "mit48px"),
+        ("inpainter", "aot"),
+        ("translator", "google"),
+    ]

--- a/tests/test_windows_context_menu_command_snapshot.py
+++ b/tests/test_windows_context_menu_command_snapshot.py
@@ -1,0 +1,43 @@
+import os
+
+import pytest
+
+from utils import windows_context_menu
+
+
+def test_get_command_snapshot_uses_pythonw_when_available(monkeypatch):
+    repo_root = "/repo"
+    python_exe = "/opt/python/python.exe"
+    pythonw_exe = "/opt/python/pythonw.exe"
+
+    monkeypatch.setattr(windows_context_menu.sys, "executable", python_exe)
+
+    launch_py = os.path.join(repo_root, "launch.py")
+
+    def fake_isfile(path):
+        return path in {launch_py, pythonw_exe}
+
+    monkeypatch.setattr(windows_context_menu.os.path, "isfile", fake_isfile)
+
+    cmd = windows_context_menu.get_command(repo_root)
+    assert cmd == f'"{pythonw_exe}" "{launch_py}" "--proj-dir" "%1"'
+
+
+def test_get_command_snapshot_falls_back_to_python_exe(monkeypatch):
+    repo_root = "/repo"
+    python_exe = "/opt/venv/bin/python"
+
+    monkeypatch.setattr(windows_context_menu.sys, "executable", python_exe)
+
+    launch_py = os.path.join(repo_root, "launch.py")
+    monkeypatch.setattr(windows_context_menu.os.path, "isfile", lambda path: path == launch_py)
+
+    cmd = windows_context_menu.get_command(repo_root)
+    assert cmd == f'"{python_exe}" "{launch_py}" "--proj-dir" "%1"'
+
+
+def test_get_command_raises_when_launch_py_missing(monkeypatch):
+    monkeypatch.setattr(windows_context_menu.os.path, "isfile", lambda _path: False)
+
+    with pytest.raises(FileNotFoundError):
+        windows_context_menu.get_command("/missing")


### PR DESCRIPTION
### Motivation
- Ensure model-package selection logic and config defaulting are covered by automated tests to prevent regressions around first-launch model download behavior. 
- Validate that runtime fallback behavior in module-setting (after download) is delegated to the module manager. 
- Add lightweight snapshot tests for launcher/context-menu command composition to catch regressions in command-line construction.

### Description
- Added `tests/test_model_packages.py` with unit tests for `get_module_classes_for_packages` covering selected packages, empty selection, unknown ids, and non-core-only selections. 
- Added `tests/test_config_model_packages_defaulting.py` to verify `ProgramConfig.load` defaulting behavior for `model_packages_enabled` when the key is missing or `null`, and that explicit values are preserved. 
- Added `tests/test_reset_modules_core_defaults.py` which uses `ast` to load `MainWindow._reset_modules_to_core_defaults` as a callable and asserts it updates `pcfg` and delegates to a fake `module_manager` so module-level fallbacks can be exercised. 
- Added `tests/test_windows_context_menu_command_snapshot.py` with snapshot-style assertions for `utils.windows_context_menu.get_command`, using `monkeypatch` to control `sys.executable` and `os.path.isfile`. 
- The config test patches a minimal `cv2` stub at import time to avoid native `libGL` dependency in CI/test environments so `utils.config` can be imported reliably. 

### Testing
- Ran `python -m compileall -f -q tests/test_model_packages.py tests/test_config_model_packages_defaulting.py tests/test_reset_modules_core_defaults.py tests/test_windows_context_menu_command_snapshot.py` which completed without errors. 
- Ran `pytest -q tests/test_model_packages.py tests/test_config_model_packages_defaulting.py tests/test_reset_modules_core_defaults.py tests/test_windows_context_menu_command_snapshot.py` which resulted in `11 passed, 1 warning` (the warning is a NumPy deprecation from `utils/io_utils.py`). 
- All new tests are standard `pytest` tests (discoverable by `pytest`) and are not utility scripts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f02fd34734832cbc8c98b5dd3a2358)