### PR TITLE
Add manifest-backed model package metadata and startup schema validation

### DIFF
--- a/data/model_manifest.json
+++ b/data/model_manifest.json
@@ -1,0 +1,188 @@
+{
+  "schema_version": 1,
+  "modules": [
+    {
+      "module_key": "ctd",
+      "category": "textdetector",
+      "size_estimate": "~260 MB",
+      "required_deps": [],
+      "support_tier": "core"
+    },
+    {
+      "module_key": "aot",
+      "category": "inpaint",
+      "size_estimate": "~220 MB",
+      "required_deps": [],
+      "support_tier": "core"
+    },
+    {
+      "module_key": "manga_ocr",
+      "category": "ocr",
+      "size_estimate": "~130 MB",
+      "required_deps": [],
+      "support_tier": "core"
+    },
+    {
+      "module_key": "mit48px_ctc",
+      "category": "ocr",
+      "size_estimate": "~160 MB",
+      "required_deps": [],
+      "support_tier": "core"
+    },
+    {
+      "module_key": "pkuseg",
+      "category": "pkuseg",
+      "size_estimate": "~50 MB",
+      "required_deps": [],
+      "support_tier": "core"
+    },
+    {
+      "module_key": "PaddleOCRVLManga",
+      "category": "ocr",
+      "size_estimate": "~1.7 GB",
+      "required_deps": [
+        "paddlepaddle"
+      ],
+      "support_tier": "advanced"
+    },
+    {
+      "module_key": "mit48px",
+      "category": "ocr",
+      "size_estimate": "~180 MB",
+      "required_deps": [],
+      "support_tier": "advanced"
+    },
+    {
+      "module_key": "mit32px",
+      "category": "ocr",
+      "size_estimate": "~140 MB",
+      "required_deps": [],
+      "support_tier": "advanced"
+    },
+    {
+      "module_key": "lama_mpe",
+      "category": "inpaint",
+      "size_estimate": "~160 MB",
+      "required_deps": [],
+      "support_tier": "advanced"
+    },
+    {
+      "module_key": "lama_large_512px",
+      "category": "inpaint",
+      "size_estimate": "~220 MB",
+      "required_deps": [],
+      "support_tier": "advanced"
+    },
+    {
+      "module_key": "lama_onnx",
+      "category": "inpaint",
+      "size_estimate": "~160 MB",
+      "required_deps": [
+        "onnxruntime"
+      ],
+      "support_tier": "optional"
+    },
+    {
+      "module_key": "lama_manga_onnx",
+      "category": "inpaint",
+      "size_estimate": "~170 MB",
+      "required_deps": [
+        "onnxruntime"
+      ],
+      "support_tier": "optional"
+    },
+    {
+      "module_key": "patchmatch",
+      "category": "inpaint",
+      "size_estimate": "~30 MB",
+      "required_deps": [],
+      "support_tier": "advanced"
+    }
+  ],
+  "packages": [
+    {
+      "id": "core",
+      "label": "Core (recommended)",
+      "description": "Text detection, inpainting, OCR, pkuseg — minimal to run",
+      "modules": [
+        {
+          "category": "textdetector",
+          "module_key": "ctd"
+        },
+        {
+          "category": "inpaint",
+          "module_key": "aot"
+        },
+        {
+          "category": "ocr",
+          "module_key": "manga_ocr"
+        },
+        {
+          "category": "ocr",
+          "module_key": "mit48px_ctc"
+        },
+        {
+          "category": "pkuseg",
+          "module_key": "pkuseg"
+        }
+      ]
+    },
+    {
+      "id": "advanced_ocr",
+      "label": "Advanced OCR",
+      "description": "PaddleOCR-VL for manga (~1.7 GB), MIT 48px/32px",
+      "modules": [
+        {
+          "category": "ocr",
+          "module_key": "PaddleOCRVLManga"
+        },
+        {
+          "category": "ocr",
+          "module_key": "mit48px"
+        },
+        {
+          "category": "ocr",
+          "module_key": "mit32px"
+        }
+      ]
+    },
+    {
+      "id": "advanced_inpaint",
+      "label": "Advanced inpainting",
+      "description": "LaMa variants, ONNX, PatchMatch",
+      "modules": [
+        {
+          "category": "inpaint",
+          "module_key": "lama_mpe"
+        },
+        {
+          "category": "inpaint",
+          "module_key": "lama_large_512px"
+        },
+        {
+          "category": "inpaint",
+          "module_key": "lama_onnx"
+        },
+        {
+          "category": "inpaint",
+          "module_key": "lama_manga_onnx"
+        },
+        {
+          "category": "inpaint",
+          "module_key": "patchmatch"
+        }
+      ]
+    },
+    {
+      "id": "optional_onnx",
+      "label": "Optional ONNX inpainting",
+      "description": "Lama 2025 / lama-manga ONNX (smaller, CPU-friendly)",
+      "modules": [
+        {
+          "category": "_optional_onnx",
+          "module_key": null
+        }
+      ]
+    }
+  ]
+}

--- a/docs/model_manifest.md
+++ b/docs/model_manifest.md
@@ -1,0 +1,61 @@
+# Model manifest maintenance
+
+The model manifest lives at `data/model_manifest.json`.
+
+## What it controls
+
+- First-launch package choices (`core`, `advanced_ocr`, etc.).
+- Package labels/descriptions in the package selector dialog.
+- Model metadata shown in **Tools → Manage models** tooltips:
+  - size estimate,
+  - required dependencies,
+  - support tier.
+
+If the manifest file is missing or invalid, the app falls back to built-in hardcoded package definitions.
+
+## Schema (v1)
+
+Top-level keys:
+
+- `schema_version` (integer)
+- `modules` (list)
+- `packages` (list)
+
+### `modules[]` required fields
+
+- `module_key` (string)
+- `category` (string)
+- `size_estimate` (string)
+- `required_deps` (list of strings)
+- `support_tier` (string)
+
+### `packages[]` required fields
+
+- `id` (string)
+- `label` (string)
+- `description` (string)
+- `modules` (list of `{ "category": str, "module_key": str|null }`)
+
+Notes:
+
+- `module_key` may be `null` only for special pseudo entries such as `_optional_onnx`.
+- Every non-null package module key must exist in `modules[]`.
+
+## Add a model
+
+1. Add a new entry in `modules[]` with all required metadata.
+2. Add it to one or more package `modules` lists.
+3. If needed, update package label/description text.
+4. Run:
+   - `python -m compileall -f -q utils/model_packages.py ui/model_manager_dialog.py utils/model_manager.py launch.py`
+
+## Remove a model
+
+1. Remove the model from all package `modules` lists.
+2. Remove its entry from `modules[]`.
+3. Run the same compile check command.
+
+## Startup validation
+
+At app startup, `utils.model_packages.validate_manifest_on_startup()` validates schema and logs errors.
+On validation failure, the app keeps running with fallback package data.

--- a/launch.py
+++ b/launch.py
@@ -219,6 +219,7 @@ def main():
     from utils.logger import setup_logging, logger as LOGGER
     from utils.io_utils import find_all_files_recursive
     from utils import config as program_config
+    from utils.model_packages import validate_manifest_on_startup
 
     from qtpy.QtCore import QTranslator, QLocale, Qt
     shared.args = args
@@ -287,6 +288,8 @@ def main():
     os.chdir(shared.PROGRAM_PATH)
 
     setup_logging(shared.LOGGING_PATH)
+    if not validate_manifest_on_startup():
+        LOGGER.warning('Model manifest validation failed; falling back to built-in model package definitions.')
 
     from utils.logger import apply_dev_mode_logging
     apply_dev_mode_logging(getattr(config, 'dev_mode', False))

--- a/ui/model_manager_dialog.py
+++ b/ui/model_manager_dialog.py
@@ -183,6 +183,17 @@ class ModelManagerDialog(QDialog):
             if not mod['can_download']:
                 continue
             cb = QCheckBox(mod['display_name'])
+            meta = mod.get('manifest_meta') or {}
+            tooltip_bits = []
+            if meta.get('size_estimate'):
+                tooltip_bits.append(self.tr('Size: {0}').format(meta['size_estimate']))
+            deps = meta.get('required_deps') or []
+            if deps:
+                tooltip_bits.append(self.tr('Dependencies: {0}').format(', '.join(deps)))
+            if meta.get('support_tier'):
+                tooltip_bits.append(self.tr('Support tier: {0}').format(meta['support_tier']))
+            if tooltip_bits:
+                cb.setToolTip('\n'.join(tooltip_bits))
             cb.setProperty('module_info', mod)
             self.downloadCheckboxLayout.addWidget(cb, row, col)
             self._check_boxes.append(cb)

--- a/utils/model_manager.py
+++ b/utils/model_manager.py
@@ -176,6 +176,7 @@ def get_all_downloadable_modules() -> List[Dict[str, Any]]:
     Returns a list of dicts: category_label, display_name, module_class, can_download.
     """
     from modules import INPAINTERS, TEXTDETECTORS, OCR, TRANSLATORS
+    from .model_packages import get_module_manifest_metadata
 
     categories = [
         (TEXTDETECTORS, "Detect"),
@@ -193,11 +194,13 @@ def get_all_downloadable_modules() -> List[Dict[str, Any]]:
             on_load = getattr(module_class, "download_file_on_load", False)
             display_name = module_key
             can_download = has_list and not on_load
+            manifest_meta = get_module_manifest_metadata(module_key)
             result.append({
                 "category_label": category_label,
                 "display_name": display_name,
                 "module_class": module_class,
                 "can_download": can_download,
+                "manifest_meta": manifest_meta,
             })
     return result
 

--- a/utils/model_packages.py
+++ b/utils/model_packages.py
@@ -7,10 +7,13 @@ None = legacy "download all" for existing installs; ["core"] = minimal default f
 """
 from __future__ import annotations
 
-from typing import List, Optional, Tuple, Any
+import json
+import logging
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
 
 # Registry name -> module_key. pkuseg is a special key (handled in prepare_local_files).
-MODEL_PACKAGES = {
+FALLBACK_MODEL_PACKAGES = {
     "core": [
         ("textdetector", "ctd"),
         ("inpaint", "aot"),
@@ -37,12 +40,288 @@ MODEL_PACKAGES = {
 }
 
 # Human-readable labels and short descriptions for the first-launch dialog
-PACKAGE_LABELS = {
+FALLBACK_PACKAGE_LABELS = {
     "core": ("Core (recommended)", "Text detection, inpainting, OCR, pkuseg — minimal to run"),
     "advanced_ocr": ("Advanced OCR", "PaddleOCR-VL for manga (~1.7 GB), MIT 48px/32px"),
     "advanced_inpaint": ("Advanced inpainting", "LaMa variants, ONNX, PatchMatch"),
     "optional_onnx": ("Optional ONNX inpainting", "Lama 2025 / lama-manga ONNX (smaller, CPU-friendly)"),
 }
+
+FALLBACK_MODULE_MANIFEST = {
+    "ctd": {
+        "module_key": "ctd",
+        "category": "textdetector",
+        "size_estimate": "~260 MB",
+        "required_deps": [],
+        "support_tier": "core",
+    },
+    "aot": {
+        "module_key": "aot",
+        "category": "inpaint",
+        "size_estimate": "~220 MB",
+        "required_deps": [],
+        "support_tier": "core",
+    },
+    "manga_ocr": {
+        "module_key": "manga_ocr",
+        "category": "ocr",
+        "size_estimate": "~130 MB",
+        "required_deps": [],
+        "support_tier": "core",
+    },
+    "mit48px_ctc": {
+        "module_key": "mit48px_ctc",
+        "category": "ocr",
+        "size_estimate": "~160 MB",
+        "required_deps": [],
+        "support_tier": "core",
+    },
+    "pkuseg": {
+        "module_key": "pkuseg",
+        "category": "pkuseg",
+        "size_estimate": "~50 MB",
+        "required_deps": [],
+        "support_tier": "core",
+    },
+    "PaddleOCRVLManga": {
+        "module_key": "PaddleOCRVLManga",
+        "category": "ocr",
+        "size_estimate": "~1.7 GB",
+        "required_deps": ["paddlepaddle"],
+        "support_tier": "advanced",
+    },
+    "mit48px": {
+        "module_key": "mit48px",
+        "category": "ocr",
+        "size_estimate": "~180 MB",
+        "required_deps": [],
+        "support_tier": "advanced",
+    },
+    "mit32px": {
+        "module_key": "mit32px",
+        "category": "ocr",
+        "size_estimate": "~140 MB",
+        "required_deps": [],
+        "support_tier": "advanced",
+    },
+    "lama_mpe": {
+        "module_key": "lama_mpe",
+        "category": "inpaint",
+        "size_estimate": "~160 MB",
+        "required_deps": [],
+        "support_tier": "advanced",
+    },
+    "lama_large_512px": {
+        "module_key": "lama_large_512px",
+        "category": "inpaint",
+        "size_estimate": "~220 MB",
+        "required_deps": [],
+        "support_tier": "advanced",
+    },
+    "lama_onnx": {
+        "module_key": "lama_onnx",
+        "category": "inpaint",
+        "size_estimate": "~160 MB",
+        "required_deps": ["onnxruntime"],
+        "support_tier": "optional",
+    },
+    "lama_manga_onnx": {
+        "module_key": "lama_manga_onnx",
+        "category": "inpaint",
+        "size_estimate": "~170 MB",
+        "required_deps": ["onnxruntime"],
+        "support_tier": "optional",
+    },
+    "patchmatch": {
+        "module_key": "patchmatch",
+        "category": "inpaint",
+        "size_estimate": "~30 MB",
+        "required_deps": [],
+        "support_tier": "advanced",
+    },
+}
+
+_LOGGER = logging.getLogger(__name__)
+_MANIFEST_PATH = Path(__file__).resolve().parents[1] / "data" / "model_manifest.json"
+_MANIFEST_CACHE: Optional[Dict[str, Any]] = None
+
+
+def _fallback_manifest() -> Dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "packages": [
+            {
+                "id": package_id,
+                "label": label,
+                "description": desc,
+                "modules": [
+                    {"category": category, "module_key": module_key}
+                    for category, module_key in entries
+                ],
+            }
+            for package_id, entries in FALLBACK_MODEL_PACKAGES.items()
+            for label, desc in [FALLBACK_PACKAGE_LABELS.get(package_id, (package_id, ""))]
+        ],
+        "modules": list(FALLBACK_MODULE_MANIFEST.values()),
+    }
+
+
+def _validate_manifest_data(manifest_data: Dict[str, Any]) -> List[str]:
+    errors: List[str] = []
+    if not isinstance(manifest_data, dict):
+        return ["Manifest root must be a JSON object."]
+
+    if not isinstance(manifest_data.get("schema_version"), int):
+        errors.append("schema_version must be an integer.")
+
+    modules = manifest_data.get("modules")
+    if not isinstance(modules, list):
+        errors.append("modules must be a list.")
+        modules = []
+    module_keys: set[str] = set()
+    for idx, module in enumerate(modules):
+        ctx = f"modules[{idx}]"
+        if not isinstance(module, dict):
+            errors.append(f"{ctx} must be an object.")
+            continue
+        for req in ("module_key", "category", "size_estimate", "required_deps", "support_tier"):
+            if req not in module:
+                errors.append(f"{ctx}.{req} is required.")
+        key = module.get("module_key")
+        if not isinstance(key, str) or not key:
+            errors.append(f"{ctx}.module_key must be a non-empty string.")
+        elif key in module_keys:
+            errors.append(f"{ctx}.module_key '{key}' is duplicated.")
+        else:
+            module_keys.add(key)
+        if not isinstance(module.get("required_deps"), list) or any(not isinstance(d, str) for d in module.get("required_deps", [])):
+            errors.append(f"{ctx}.required_deps must be a list of strings.")
+
+    packages = manifest_data.get("packages")
+    if not isinstance(packages, list):
+        errors.append("packages must be a list.")
+        packages = []
+    package_ids: set[str] = set()
+    for idx, package in enumerate(packages):
+        ctx = f"packages[{idx}]"
+        if not isinstance(package, dict):
+            errors.append(f"{ctx} must be an object.")
+            continue
+        pid = package.get("id")
+        if not isinstance(pid, str) or not pid:
+            errors.append(f"{ctx}.id must be a non-empty string.")
+        elif pid in package_ids:
+            errors.append(f"{ctx}.id '{pid}' is duplicated.")
+        else:
+            package_ids.add(pid)
+        if not isinstance(package.get("label"), str):
+            errors.append(f"{ctx}.label must be a string.")
+        if not isinstance(package.get("description"), str):
+            errors.append(f"{ctx}.description must be a string.")
+        refs = package.get("modules")
+        if not isinstance(refs, list):
+            errors.append(f"{ctx}.modules must be a list.")
+            continue
+        for ref_idx, ref in enumerate(refs):
+            ref_ctx = f"{ctx}.modules[{ref_idx}]"
+            if not isinstance(ref, dict):
+                errors.append(f"{ref_ctx} must be an object.")
+                continue
+            if not isinstance(ref.get("category"), str):
+                errors.append(f"{ref_ctx}.category must be a string.")
+            module_key = ref.get("module_key")
+            if module_key is not None and not isinstance(module_key, str):
+                errors.append(f"{ref_ctx}.module_key must be null or string.")
+            if isinstance(module_key, str) and module_key not in module_keys and ref.get("category") not in {"_optional_onnx"}:
+                errors.append(f"{ref_ctx}.module_key '{module_key}' is missing from modules.")
+    return errors
+
+
+def _parse_manifest_data(manifest_data: Dict[str, Any]) -> Dict[str, Any]:
+    package_map: Dict[str, List[Tuple[str, Optional[str]]]] = {}
+    package_labels: Dict[str, Tuple[str, str]] = {}
+    modules_by_key: Dict[str, Dict[str, Any]] = {}
+    for module in manifest_data.get("modules", []):
+        if isinstance(module, dict) and isinstance(module.get("module_key"), str):
+            modules_by_key[module["module_key"]] = module
+    for package in manifest_data.get("packages", []):
+        if not isinstance(package, dict):
+            continue
+        package_id = package.get("id")
+        if not isinstance(package_id, str):
+            continue
+        package_labels[package_id] = (
+            str(package.get("label", package_id)),
+            str(package.get("description", "")),
+        )
+        refs: List[Tuple[str, Optional[str]]] = []
+        for ref in package.get("modules", []):
+            if not isinstance(ref, dict):
+                continue
+            category = ref.get("category")
+            module_key = ref.get("module_key")
+            if not isinstance(category, str):
+                continue
+            refs.append((category, module_key if isinstance(module_key, str) else None))
+        package_map[package_id] = refs
+    return {
+        "schema_version": manifest_data.get("schema_version", 1),
+        "model_packages": package_map,
+        "package_labels": package_labels,
+        "modules_by_key": modules_by_key,
+        "manifest_path": str(_MANIFEST_PATH),
+        "source": "manifest",
+    }
+
+
+def _load_model_manifest() -> Dict[str, Any]:
+    global _MANIFEST_CACHE
+    if _MANIFEST_CACHE is not None:
+        return _MANIFEST_CACHE
+
+    if _MANIFEST_PATH.exists():
+        try:
+            manifest_data = json.loads(_MANIFEST_PATH.read_text(encoding="utf-8"))
+            errors = _validate_manifest_data(manifest_data)
+            if errors:
+                raise ValueError("; ".join(errors))
+            _MANIFEST_CACHE = _parse_manifest_data(manifest_data)
+            return _MANIFEST_CACHE
+        except Exception as e:
+            _LOGGER.warning("Invalid model manifest at %s: %s. Falling back to hardcoded package data.", _MANIFEST_PATH, e)
+    _MANIFEST_CACHE = _parse_manifest_data(_fallback_manifest())
+    _MANIFEST_CACHE["source"] = "fallback"
+    return _MANIFEST_CACHE
+
+
+def validate_manifest_on_startup() -> bool:
+    """Validate manifest schema at app startup. Returns True when valid or intentionally missing."""
+    if not _MANIFEST_PATH.exists():
+        _LOGGER.info("Model manifest not found at %s, using hardcoded fallback package data.", _MANIFEST_PATH)
+        return True
+    try:
+        manifest_data = json.loads(_MANIFEST_PATH.read_text(encoding="utf-8"))
+    except Exception as e:
+        _LOGGER.error("Failed to read model manifest %s: %s", _MANIFEST_PATH, e)
+        return False
+    errors = _validate_manifest_data(manifest_data)
+    if errors:
+        _LOGGER.error("Model manifest schema validation failed (%s): %s", _MANIFEST_PATH, " | ".join(errors))
+        return False
+    return True
+
+
+def get_module_manifest_metadata(module_key: str) -> Dict[str, Any]:
+    """Return manifest metadata for a module key, or an empty dict."""
+    manifest = _load_model_manifest()
+    data = manifest["modules_by_key"].get(module_key)
+    return data.copy() if isinstance(data, dict) else {}
+
+
+# Backward-compatible module-level constants consumed by existing UI code.
+_MANIFEST = _load_model_manifest()
+MODEL_PACKAGES = _MANIFEST["model_packages"]
+PACKAGE_LABELS = _MANIFEST["package_labels"]
 
 
 def get_module_classes_for_packages(


### PR DESCRIPTION
### Motivation

- Centralize model/package metadata (size, deps, support tier) in a single manifest so package composition can be edited without code churn.  
- Surface manifest metadata in the existing Manage Models UI while preserving previous behavior for installs that do not provide a manifest.  
- Validate manifest schema at startup to fail fast and fall back to known-good builtins instead of causing runtime errors.

### Description

- Add a JSON manifest at `data/model_manifest.json` containing `modules[]` and `packages[]` with `module_key`, `category`, `size_estimate`, `required_deps`, and `support_tier` entries.  
- Refactor `utils/model_packages.py` to load and parse the manifest, provide `_load_model_manifest()`, `validate_manifest_on_startup()`, and `get_module_manifest_metadata()`, and keep backward-compatible `MODEL_PACKAGES`/`PACKAGE_LABELS` by falling back to built-in data when the manifest is missing or invalid.  
- Update `utils/model_manager.py` so `get_all_downloadable_modules()` attaches `manifest_meta` to each module entry for UI use.  
- Update `ui/model_manager_dialog.py` to display manifest metadata as checkbox tooltips (size, dependencies, support tier) when rendering the Download models list (trigger: Tools → Manage models → Download models); this reuses the existing UI flow and does not add new top-level controls, and can be manually verified by opening the dialog and hovering the module checkboxes.  
- Wire startup validation into `launch.py` so `validate_manifest_on_startup()` runs at app boot and logs a fallback warning if the manifest is invalid, and add `docs/model_manifest.md` documenting the schema and how to add/remove models.

### Testing

- Ran compilation checks with `python -m compileall -f -q utils/model_packages.py utils/model_manager.py ui/model_manager_dialog.py launch.py docs/model_manifest.md data/model_manifest.json`, which completed successfully.  
- Ran a manifest smoke test (`from utils import model_packages; model_packages.validate_manifest_on_startup()`) which returned `True` and `_load_model_manifest().get('source')` was `manifest`.  
- Exercised package resolution with a small registry stub and `get_module_classes_for_packages(['core'], registries=fake)` which returned expected results (`classes_len 1`).  
- Attempted a UI import smoke check (`import ui.model_manager_dialog`) but it failed in this environment due to a missing system dependency (`libGL.so.1`), so UI runtime verification was limited to static inspection and tooltip wiring tests; manifest-driven behavior falls back to builtins when validation fails.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f02fd9f5f8832c83f490717785acf1)