### PR TITLE
Add first-run local-only option, Import-local models, clearer model-missing guidance, and offline telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ This fork adds **many new optional modules** (detectors, OCR engines, inpainters
 ## Quick start
 
 1. **Clone and run:** `git clone https://github.com/thomaswantstobeaskeleton/BallonsTranslator-Pro.git && cd BallonsTranslator-Pro && python launch.py`
-2. **First run:** Installs base deps. When `config.json` is missing (e.g. fresh install), a **model package selector** appears: choose which packages to download (Core only, or Core + Advanced OCR / Advanced inpainting, etc.). The **main window opens immediately**; model packages then download in the background (so you can retry without restarting if a download fails). Use **Tools → Models → Retry model downloads** to retry after a failed or interrupted download. After a successful download, detector/OCR/inpainter/translator are set to core defaults (ctd, manga_ocr, aot, google). You can download more later via **Tools → Manage models**. If `config.json` already existed, all models are downloaded as before (legacy). Config loads from `config/config.example.json` when missing; manual download paths are shown in the log.
+2. **First run:** Installs base deps. When `config.json` is missing (e.g. fresh install), a **model package selector** appears: choose which packages to download (Core only, or Core + Advanced OCR / Advanced inpainting, etc.). The **main window opens immediately**; model packages then download in the background (so you can retry without restarting if a download fails). First-run dialog now also includes **Skip all downloads, run with local-only modules** for offline use (no startup download). Use **Tools → Models → Retry model downloads** to retry after a failed or interrupted download. After a successful download, detector/OCR/inpainter/translator are set to core defaults (ctd, manga_ocr, aot, google). You can download more later via **Tools → Manage models**. If `config.json` already existed, all models are downloaded as before (legacy). Config loads from `config/config.example.json` when missing; manual download paths are shown in the log.
 3. **Config:** Open the settings panel → choose **Text detection**, **OCR**, **Inpainting**, **Translation** from the dropdowns
 4. **New modules** appear automatically; install only the dependencies for the modules you use
 5. **Updating:** Use **View → Help → Update from GitHub** to pull the latest changes without re-downloading; your config and local files are not overwritten. *This only works if you cloned the repo with git (e.g. `git clone ...`). If you downloaded a ZIP, download the latest ZIP from GitHub and replace the folder to update.* Optional: **Config → General → Auto update from GitHub on startup** (can cause issues — see tooltip).
@@ -374,10 +374,20 @@ In **text edit mode**, right-click on the canvas to open a context menu. Items a
 3. **Check** — refresh status; optionally enable **Check compatibility (slow)** to try loading each module and detect missing deps.
 4. Select rows in the download section → **Download selected** — downloads missing models that have a file list to `data/models/`. Modules with no file list (optional pip) are not downloadable here; install them with pip as shown in the check table.
 5. Models are stored per module (e.g. `comictextdetector.pt.onnx`, `lama_large_512px.ckpt`).
+6. **Import local model directory...** lets you copy an existing local model folder into `data/models/` (offline migration helper).
 
 **Module visibility:** Without **Config → General → Dev mode**, detector/OCR/translator dropdowns show only modules that are compatible with your environment (e.g. Python version) and ready to use. With **Dev mode** enabled, all registered modules appear so you can test or install optional ones (e.g. Nemotron OCR v1 requires Python 3.12+; see **docs/OPTIONAL_DEPENDENCIES.md**).
 
 ---
+
+
+### Offline / local-only flow
+
+1. On first run, choose **Skip all downloads, run with local-only modules**.
+2. Open **Tools → Manage models** and use **Import local model directory...** (or Download selected when online).
+3. In Config module selectors, choose only modules marked as downloaded/compatible in Manage models.
+4. If a selected module is missing files, selector/pipeline errors now include direct guidance to **Tools → Manage models**.
+5. Optional local diagnostics: enable **Config → General → Dev mode + diagnostic mode** to log offline-path events (`startup.offline_local_only`) locally.
 
 ### Run presets and pipeline stages
 

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -24,7 +24,7 @@
    `git clone https://github.com/thomaswantstobeaskeleton/BallonsTranslator-Pro.git && cd BallonsTranslator-Pro && python launch.py`
 
 2. **首次运行：**  
-   自动安装基础依赖。若不存在 `config.json`（全新安装），会弹出 **模型包选择** 对话框：选择要下载的模型包（仅核心包，或核心 + 高级 OCR / 高级修复等）。**主窗口会立即打开**，模型包在后台下载；若下载失败或中断，无需重启，使用 **工具 → 模型 → 重试下载模型** 即可。下载成功后，检测器/OCR/修复/翻译会恢复为核心默认（ctd、manga_ocr、aot、google）。之后可通过 **工具 → 管理模型** 下载更多模型。若已有 `config.json`，则按当前配置下载；缺省仅下载核心包，避免占用多余磁盘（见 [Issue #15](https://github.com/thomaswantstobeaskeleton/BallonsTranslator-Pro/issues/15)）。
+   自动安装基础依赖。若不存在 `config.json`（全新安装），会弹出 **模型包选择** 对话框：选择要下载的模型包（仅核心包，或核心 + 高级 OCR / 高级修复等）。**主窗口会立即打开**，模型包在后台下载；若下载失败或中断，无需重启，使用 **工具 → 模型 → 重试下载模型** 即可。首次启动还新增 **跳过所有下载（仅本地模块）** 选项，适合离线场景。下载成功后，检测器/OCR/修复/翻译会恢复为核心默认（ctd、manga_ocr、aot、google）。之后可通过 **工具 → 管理模型** 下载更多模型。若已有 `config.json`，则按当前配置下载；缺省仅下载核心包，避免占用多余磁盘（见 [Issue #15](https://github.com/thomaswantstobeaskeleton/BallonsTranslator-Pro/issues/15)）。
 
 3. **配置：** 打开设置面板 → 在 **文本检测**、**OCR**、**图像修复**、**翻译** 下拉框中选择模块。
 
@@ -67,6 +67,15 @@
 | **修复** | lama_large_512px | mask_dilation 1–2，inpaint_size 1024 |
 
 更多质量分级与设置见 [docs/MANHUA_BEST_SETTINGS.md](docs/MANHUA_BEST_SETTINGS.md)、[docs/QUALITY_RANKINGS.md](docs/QUALITY_RANKINGS.md)。
+
+---
+
+## 离线 / 仅本地模块流程
+
+1. 首次启动时可选择 **跳过所有下载（仅本地模块）**。
+2. 打开 **工具 → 管理模型**，使用 **导入本地模型目录...**（在线时也可“下载所选”）。
+3. 模块下拉框与流水线在模型缺失时，会明确提示前往 **工具 → 管理模型** 处理。
+4. 如需本地诊断日志，可开启 `diagnostic mode`，会记录 `startup.offline_local_only` 等离线路径事件（仅本地日志）。
 
 ---
 

--- a/launch.py
+++ b/launch.py
@@ -335,6 +335,9 @@ def main():
         dialog = ModelPackageSelectorDialog()
         dialog.exec()
         config.model_packages_enabled = dialog.get_selected_package_ids()
+        config.offline_local_only_mode = dialog.is_offline_local_only_selected()
+        if config.offline_local_only_mode:
+            LOGGER.info("First-run mode selected: local-only (skip all model downloads).")
         try:
             from utils.config import save_config
             save_config()

--- a/ui/mainwindow.py
+++ b/ui/mainwindow.py
@@ -1818,6 +1818,12 @@ class MainWindow(mainwindow_cls):
         """Run initial model download after window is shown (set by launch.py so app opens first)."""
         package_ids = getattr(pcfg, 'model_packages_enabled', None)
         if package_ids is not None and len(package_ids) == 0:
+            LOGGER.info("Initial model download skipped (local-only mode selected).")
+            log_diagnostic_event(
+                "startup.offline_local_only",
+                selected=True,
+                package_ids=[],
+            )
             return
         dlg = ModelDownloadProgressDialog(self)
         thread = ModelDownloadThread(self)
@@ -1844,9 +1850,14 @@ class MainWindow(mainwindow_cls):
         """Retry downloading model packages (Tools → Retry model downloads). Useful when first-run download failed."""
         package_ids = getattr(pcfg, 'model_packages_enabled', None)
         if package_ids is not None and len(package_ids) == 0:
+            log_diagnostic_event(
+                "startup.offline_local_only",
+                selected=True,
+                retry_requested=True,
+            )
             create_info_dialog({
                 'title': self.tr('No model packages selected.'),
-                'text': self.tr('Use Tools → Manage models to download individual models, or restart the app to choose packages again.'),
+                'text': self.tr('First-run local-only mode is active. Use Tools → Manage models to import/download models, or edit config/config.json to enable packages and restart.'),
             })
             return
         dlg = ModelDownloadProgressDialog(self)

--- a/ui/model_manager_dialog.py
+++ b/ui/model_manager_dialog.py
@@ -5,6 +5,7 @@ and download selected models. Opened from Tools → Manage models...
 from __future__ import annotations
 
 import os
+import shutil
 from typing import List, Dict, Any
 
 from qtpy.QtCore import Qt, Signal, QThread, QObject
@@ -25,6 +26,7 @@ from qtpy.QtWidgets import (
     QHeaderView,
     QAbstractItemView,
     QGridLayout,
+    QFileDialog,
 )
 
 from utils.model_manager import (
@@ -145,10 +147,14 @@ class ModelManagerDialog(QDialog):
         select_all_btn.clicked.connect(self._select_all_download)
         deselect_all_btn = QPushButton(self.tr('Deselect all'))
         deselect_all_btn.clicked.connect(self._deselect_all_download)
+        import_local_btn = QPushButton(self.tr('Import local model directory...'))
+        import_local_btn.setToolTip(self.tr('Copy model files from an existing local folder into this app\'s data/models directory.'))
+        import_local_btn.clicked.connect(self._on_import_local_model_dir)
         self.downloadSelectedBtn = QPushButton(self.tr('Download selected'))
         self.downloadSelectedBtn.clicked.connect(self._on_download_clicked)
         btn_row.addWidget(select_all_btn)
         btn_row.addWidget(deselect_all_btn)
+        btn_row.addWidget(import_local_btn)
         btn_row.addWidget(self.downloadSelectedBtn)
         btn_row.addStretch()
         download_layout.addLayout(btn_row)
@@ -270,6 +276,38 @@ class ModelManagerDialog(QDialog):
         self._download_worker.finished.connect(self._on_download_finished)
         self._download_worker.error.connect(self._on_download_error)
         self._download_thread.start()
+
+    def _on_import_local_model_dir(self):
+        from utils import shared
+        src_dir = QFileDialog.getExistingDirectory(self, self.tr('Select local model directory'))
+        if not src_dir:
+            return
+        dst_root = os.path.join(getattr(shared, 'PROGRAM_PATH', os.getcwd()), 'data', 'models')
+        os.makedirs(dst_root, exist_ok=True)
+        copied = 0
+        overwritten = 0
+        errors = []
+        for root, _, files in os.walk(src_dir):
+            rel = os.path.relpath(root, src_dir)
+            dst_dir = dst_root if rel == "." else os.path.join(dst_root, rel)
+            os.makedirs(dst_dir, exist_ok=True)
+            for name in files:
+                src_fp = os.path.join(root, name)
+                dst_fp = os.path.join(dst_dir, name)
+                try:
+                    if os.path.exists(dst_fp):
+                        overwritten += 1
+                    else:
+                        copied += 1
+                    shutil.copy2(src_fp, dst_fp)
+                except Exception as e:
+                    errors.append(f"{src_fp}: {e}")
+        msg = self.tr('Import complete.\nNew files: {}\nOverwritten: {}\nDestination: {}').format(copied, overwritten, dst_root)
+        if errors:
+            msg += '\n\n' + self.tr('Some files failed to import (showing first 5):\n{}').format('\n'.join(errors[:5]))
+            QMessageBox.warning(self, self.tr('Import local models'), msg)
+        else:
+            QMessageBox.information(self, self.tr('Import local models'), msg)
 
     def _on_download_finished(self, success: int, failed: int, errors: List[str]):
         if self._download_thread and self._download_thread.isRunning():

--- a/ui/model_package_selector_dialog.py
+++ b/ui/model_package_selector_dialog.py
@@ -1,7 +1,7 @@
 """
 First-launch dialog to choose which model packages to download (Issue #15).
 Only shown when config file did not exist (new user). User can select packages
-(e.g. Core only, or Core + Advanced OCR) then download; or skip to use Core only.
+(e.g. Core only, or Core + Advanced OCR), skip to Core-only, or run local-only.
 """
 from __future__ import annotations
 
@@ -62,11 +62,15 @@ class ModelPackageSelectorDialog(QDialog):
         skip_btn = QPushButton(self.tr("Skip (Core only)"))
         skip_btn.setToolTip(self.tr("Download only the Core package (recommended minimum)."))
         skip_btn.clicked.connect(self._on_skip)
+        local_only_btn = QPushButton(self.tr("Skip all downloads (local-only)"))
+        local_only_btn.setToolTip(self.tr("Do not download any model package now. Use only already-local modules/files."))
+        local_only_btn.clicked.connect(self._on_local_only)
         download_btn = QPushButton(self.tr("Download selected"))
         download_btn.setDefault(True)
         download_btn.setFocus()
         download_btn.clicked.connect(self._on_download)
         btn_row.addWidget(skip_btn)
+        btn_row.addWidget(local_only_btn)
         btn_row.addWidget(download_btn)
         layout.addLayout(btn_row)
 
@@ -75,6 +79,12 @@ class ModelPackageSelectorDialog(QDialog):
 
     def _on_skip(self):
         self._result = ["core"]
+        self._offline_local_only = False
+        self.accept()
+
+    def _on_local_only(self):
+        self._result = []
+        self._offline_local_only = True
         self.accept()
 
     def _on_download(self):
@@ -86,3 +96,7 @@ class ModelPackageSelectorDialog(QDialog):
     def get_selected_package_ids(self):
         """Return the selected package IDs (set after dialog is accepted)."""
         return getattr(self, "_result", ["core"])
+
+    def is_offline_local_only_selected(self) -> bool:
+        """True if user explicitly selected first-run local-only mode."""
+        return bool(getattr(self, "_offline_local_only", False))

--- a/ui/module_manager.py
+++ b/ui/module_manager.py
@@ -45,6 +45,14 @@ from utils.cancellation import CancelFlag
 cfg_module = pcfg.module
 
 
+def _model_missing_guidance(module_label: str, module_name: str = "") -> str:
+    suffix = f" ({module_name})" if module_name else ""
+    return (
+        f"{module_label}{suffix} is not ready: required model files are missing or incompatible.\n"
+        "Open Tools → Manage models to check/download/import local models, then select an available module."
+    )
+
+
 class ModuleThread(QThread):
 
     finish_set_module = Signal()
@@ -105,7 +113,8 @@ class ModuleThread(QThread):
             else:
                 create_error_dialog(
                     KeyError(module_name),
-                    self._failed_set_module_msg + " " + self.tr("No fallback available."),
+                    self._failed_set_module_msg + " " + self.tr("No fallback available.") + "\n"
+                    + self.tr("Open Tools → Manage models to check or import local model files."),
                 )
                 self.finish_set_module.emit()
                 return
@@ -956,7 +965,7 @@ class ImgtransThread(QThread):
                 if self.textdetector is None:
                     create_error_dialog(
                         RuntimeError("Text detector module is not set or failed to load."),
-                        self.tr("Text detector is not available. Switch to a working detector in Config or install the required model."),
+                        self.tr(_model_missing_guidance("Text detector", getattr(cfg_module, "textdetector", ""))),
                         "DetectorNotSet",
                     )
                     self.stop_requested = True
@@ -1008,7 +1017,12 @@ class ImgtransThread(QThread):
                         register_batch_skip(imgname, "detection", str(e))
                     except Exception:
                         pass
-                    create_error_dialog(e, self.tr('Text Detection Failed.') + f' (page: {imgname})', 'TextDetectFailed')
+                    create_error_dialog(
+                        e,
+                        self.tr('Text Detection Failed.') + f' (page: {imgname})\n'
+                        + self.tr(_model_missing_guidance("Text detector", getattr(cfg_module, "textdetector", ""))),
+                        'TextDetectFailed',
+                    )
                     blk_list = []
                 self.detect_counter += 1
                 if pcfg.module.keep_exist_textlines:
@@ -1243,7 +1257,12 @@ class ImgtransThread(QThread):
                         register_batch_skip(imgname, "ocr", str(e))
                     except Exception:
                         pass
-                    create_error_dialog(e, self.tr('OCR Failed.') + f' (page: {imgname})', 'OCRFailed')
+                    create_error_dialog(
+                        e,
+                        self.tr('OCR Failed.') + f' (page: {imgname})\n'
+                        + self.tr(_model_missing_guidance("OCR", getattr(cfg_module, "ocr", ""))),
+                        'OCRFailed',
+                    )
                 self.ocr_counter += 1
 
                 if pcfg.restore_ocr_empty:
@@ -2043,7 +2062,10 @@ class ModuleManager(QObject):
                 translator = fallback
                 cfg_module.translator = fallback
             else:
-                create_error_dialog(ValueError(self.tr("No translator module available.")), self.tr("Failed to set Translator."))
+                create_error_dialog(
+                    ValueError(self.tr("No translator module available.")),
+                    self.tr("Failed to set Translator.") + "\n" + self.tr(_model_missing_guidance("Translator", translator)),
+                )
                 return
         if self.translate_thread.isRunning():
             LOGGER.warning('Terminating a running translation thread.')
@@ -2068,7 +2090,10 @@ class ModuleManager(QObject):
                 inpainter = fallback
                 cfg_module.inpainter = fallback
             else:
-                create_error_dialog(ValueError(self.tr("No inpainter module available.")), self.tr("Failed to set Inpainter."))
+                create_error_dialog(
+                    ValueError(self.tr("No inpainter module available.")),
+                    self.tr("Failed to set Inpainter.") + "\n" + self.tr(_model_missing_guidance("Inpainter", inpainter)),
+                )
                 return
         
         if self.inpaint_thread.isRunning():
@@ -2084,7 +2109,13 @@ class ModuleManager(QObject):
             textdetector = cfg_module.textdetector
         valid = GET_VALID_TEXTDETECTORS()
         if textdetector not in valid:
-            fallback = "ctd" if "ctd" in valid else (valid[0] if valid else "paddle_det")
+            fallback = "ctd" if "ctd" in valid else (valid[0] if valid else None)
+            if fallback is None:
+                create_error_dialog(
+                    ValueError(self.tr("No text detector module available.")),
+                    self.tr("Failed to set Text Detector.") + "\n" + self.tr(_model_missing_guidance("Text detector", textdetector)),
+                )
+                return
             LOGGER.warning(
                 "Text detector '%s' is not available (e.g. not yet integrated). Using '%s'.",
                 textdetector, fallback,
@@ -2148,7 +2179,10 @@ class ModuleManager(QObject):
                 ocr = fallback
                 cfg_module.ocr = fallback
             else:
-                create_error_dialog(ValueError(self.tr("No OCR module available.")), self.tr("Failed to set OCR."))
+                create_error_dialog(
+                    ValueError(self.tr("No OCR module available.")),
+                    self.tr("Failed to set OCR.") + "\n" + self.tr(_model_missing_guidance("OCR", ocr)),
+                )
                 return
         if self.ocr_thread.isRunning():
             LOGGER.warning('Terminating a running OCR thread.')

--- a/utils/config.py
+++ b/utils/config.py
@@ -490,6 +490,8 @@ class ProgramConfig(Config):
     manga_source_translate_raw_search: bool = True  # For raw sources: translate search query to Japanese/Korean/Chinese
     # Model packages to download at startup (None = legacy "all"; ["core"] = minimal). See utils.model_packages.
     model_packages_enabled: Optional[List[str]] = field(default_factory=lambda: ["core"])
+    # True when first-run explicitly chose "Skip all downloads, local-only modules".
+    offline_local_only_mode: bool = False
     # When True, show all modules in detector/OCR/translator dropdowns (including not downloaded or incompatible). When False, only show ready modules.
     dev_mode: bool = False
     # Temporary: when enabled, emit structured diagnostic logs for UI actions and pipeline stage transitions.
@@ -563,6 +565,8 @@ class ProgramConfig(Config):
         # Legacy: configs that lack this key or have null used to download all models. Default to core-only (Issue #15).
         if config_dict.get("model_packages_enabled") is None:
             config_dict["model_packages_enabled"] = ["core"]
+        if "offline_local_only_mode" not in config_dict:
+            config_dict["offline_local_only_mode"] = False
 
         return ProgramConfig(**config_dict)
     
@@ -609,6 +613,7 @@ CONFIG_KEY_ORDER = (
     "manga_source_request_delay", "manga_source_open_after_download", "manga_source_playwright_headless",
     "manga_source_translate_raw_search",
     "model_packages_enabled",
+    "offline_local_only_mode",
     "dev_mode",
     "diagnostic_mode",
     "release_caches_after_batch", "manual_mode", "skip_ignored_in_run",


### PR DESCRIPTION
### Motivation
- Provide an explicit offline first-run path so users can start the app without fetching models (use existing local model files instead).
- Make module selectors and pipeline errors actionable by surfacing clear guidance when required model files are missing or incompatible.
- Add an easy migration helper to import existing local model folders into the app’s `data/models/` so offline users can provision models without network downloads.
- Emit local-only diagnostic events so local/telemetry-aware workflows can record the offline choice for debugging and support.

### Description
- Added a new first-run button `Skip all downloads (local-only)` in the model package selector and exposed `is_offline_local_only_selected()` so launch sets `config.offline_local_only_mode` when chosen. (files: `ui/model_package_selector_dialog.py`, `launch.py`, `utils/config.py`).
- When first-run local-only is active the deferred startup download is skipped and the UI logs a diagnostic event `startup.offline_local_only`; `Tools → Retry model downloads` now shows a contextual info message for local-only mode. (file: `ui/mainwindow.py`).
- Added an **Import local model directory...** action in `Tools → Manage models` which copies a selected directory into `data/models/` and reports summary/errors to the user. (file: `ui/model_manager_dialog.py`).
- Centralized human-friendly guidance via `_model_missing_guidance()` and updated module-selection and pipeline error dialogs to recommend `Tools → Manage models` when modules are missing or incompatible. (file: `ui/module_manager.py`).
- Documented the offline/local-only flow and the import helper in both `README.md` and `README_zh_CN.md` and added the new `offline_local_only_mode` config key to persist the choice. (files: `README.md`, `README_zh_CN.md`, `utils/config.py`).
- Small telemetry/log hooks added using existing `log_diagnostic_event` so offline selection and retry events are recorded locally when `diagnostic_mode` is enabled. (files: `ui/mainwindow.py`, `utils/config.py`).

Manual verification (quick): open the app without an existing `config.json`, choose **Skip all downloads (local-only)**, then open `Tools → Manage models` and use **Import local model directory...** to copy model files into `data/models/`, and observe Manage Models shows modules as downloaded after a `Check all models` run.

### Testing
- Ran `python -m compileall -f -q ui/model_package_selector_dialog.py ui/model_manager_dialog.py ui/module_manager.py ui/mainwindow.py launch.py utils/config.py` and it completed without syntax errors.
- Ran an AST-based presence check script to confirm the new helper functions (`is_offline_local_only_selected`, `_on_local_only`, `_on_import_local_model_dir`, `_model_missing_guidance`) are present and they were found. 
- Attempted a basic runtime instantiation of `ProgramConfig()` but a platform OpenCV/OpenGL dependency (`ImportError: libGL.so.1`) prevented importing full config in this environment, so a live app startup smoke test was not executed here; the compile/AST checks above passed. 
- No automated unit tests were added or modified in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f02fdbe8a8832c8b1c68c484e7f796)