### PR TITLE
Fix post-merge syntax regressions in model package setup files

### DIFF
--- a/ui/model_package_selector_dialog.py
+++ b/ui/model_package_selector_dialog.py
@@ -19,11 +19,11 @@ from qtpy.QtWidgets import (
     QMessageBox,
 )
 
-from utils.model_packages import MODEL_PACKAGES, PACKAGE_LABELS, PACKAGE_TIERS
 from utils.model_packages import (
     MODEL_PACKAGES,
     MODEL_PACKAGE_PRESETS,
     PACKAGE_LABELS,
+    PACKAGE_TIERS,
     DEFAULT_MODEL_PACKAGE_PRESET_ID,
     get_package_ids_for_preset,
 )
@@ -57,14 +57,11 @@ class ModelPackageSelectorDialog(QDialog):
         intro.setWordWrap(True)
         layout.addWidget(intro)
 
-        group = QGroupBox(self.tr("Model packages"))
-        group_layout = QVBoxLayout(group)
         tier_order = {"Stable": 0, "Beta": 1, "Experimental": 2, "External dependency heavy": 3}
         sorted_package_ids = sorted(
             MODEL_PACKAGES.keys(),
             key=lambda pid: (tier_order.get(PACKAGE_TIERS.get(pid, "Stable"), 99), pid),
         )
-        for package_id in sorted_package_ids:
         presets_group = QGroupBox(self.tr("Recommended presets"))
         presets_layout = QVBoxLayout(presets_group)
         for preset_id, preset in MODEL_PACKAGE_PRESETS.items():
@@ -103,7 +100,7 @@ class ModelPackageSelectorDialog(QDialog):
 
         advanced_group = QGroupBox(self.tr("Manual package selection"))
         group_layout = QVBoxLayout(advanced_group)
-        for package_id in MODEL_PACKAGES:
+        for package_id in sorted_package_ids:
             label, desc = PACKAGE_LABELS.get(package_id, (package_id, ""))
             cb = QCheckBox(QCoreApplication.translate("ModelPackageCatalog", label))
             cb.setToolTip(QCoreApplication.translate("ModelPackageCatalog", desc))

--- a/utils/model_packages.py
+++ b/utils/model_packages.py
@@ -11,7 +11,6 @@ import json
 import logging
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
-from typing import Dict, List, Optional, Any
 
 from qtpy.QtCore import QT_TRANSLATE_NOOP
 
@@ -51,9 +50,17 @@ PACKAGE_TIERS = {
 }
 
 # Human-readable labels and short descriptions for the first-launch dialog
+FALLBACK_PACKAGE_LABELS = {
+    "core": ("Core (recommended)", "Text detection, inpainting, OCR, pkuseg — minimal to run"),
+    "advanced_ocr": ("Advanced OCR", "PaddleOCR-VL for manga (~1.7 GB), MIT 48px/32px"),
+    "advanced_inpaint": ("Advanced inpainting", "LaMa variants, ONNX, PatchMatch"),
+    "optional_onnx": ("Optional ONNX inpainting", "Lama 2025 / lama-manga ONNX (smaller, CPU-friendly)"),
+}
+
+# Translation extraction catalog for package labels/descriptions.
 PACKAGE_LABELS = {
     "core": (
-        QT_TRANSLATE_NOOP("ModelPackageCatalog", "Core (recommended)"),
+        QT_TRANSLATE_NOOP("ModelPackageCatalog", "Core package"),
         QT_TRANSLATE_NOOP("ModelPackageCatalog", "Text detection, inpainting, OCR, pkuseg — minimal to run"),
     ),
     "advanced_ocr": (
@@ -68,19 +75,6 @@ PACKAGE_LABELS = {
         QT_TRANSLATE_NOOP("ModelPackageCatalog", "Optional ONNX inpainting"),
         QT_TRANSLATE_NOOP("ModelPackageCatalog", "Lama 2025 / lama-manga ONNX (smaller, CPU-friendly)"),
     ),
-FALLBACK_PACKAGE_LABELS = {
-    "core": ("Core (recommended)", "Text detection, inpainting, OCR, pkuseg — minimal to run"),
-PACKAGE_LABELS = {
-    "core": ("Core (recommended) [Stable]", "Text detection, inpainting, OCR, pkuseg — minimal to run"),
-    "advanced_ocr": ("Advanced OCR [External dependency heavy]", "PaddleOCR-VL for manga (~1.7 GB), MIT 48px/32px"),
-    "advanced_inpaint": ("Advanced inpainting [Beta]", "LaMa variants, ONNX, PatchMatch"),
-    "optional_onnx": ("Optional ONNX inpainting [Experimental]", "Lama 2025 / lama-manga ONNX (smaller, CPU-friendly)"),
-# Human-readable labels and short descriptions for package-level advanced/custom mode.
-PACKAGE_LABELS = {
-    "core": ("Core package", "Text detection, inpainting, OCR, pkuseg — minimal to run"),
-    "advanced_ocr": ("Advanced OCR", "PaddleOCR-VL for manga (~1.7 GB), MIT 48px/32px"),
-    "advanced_inpaint": ("Advanced inpainting", "LaMa variants, ONNX, PatchMatch"),
-    "optional_onnx": ("Optional ONNX inpainting", "Lama 2025 / lama-manga ONNX (smaller, CPU-friendly)"),
 }
 
 FALLBACK_MODULE_MANIFEST = {


### PR DESCRIPTION
### Motivation

- Restore broken model package metadata and first-run selector UI behavior after a bad merge introduced syntax/logic regressions that caused import/compile errors and an unusable dialog.

### Description

- Repaired `utils/model_packages.py` by removing a duplicated typing import, restoring `FALLBACK_PACKAGE_LABELS`, and reintroducing a clean `PACKAGE_LABELS` translation catalog using `QT_TRANSLATE_NOOP` so fallback manifest parsing and translation extraction work.
- Cleaned up leftover/duplicated/conflicting label definitions introduced by the merge so manifest fallback and manifest-driven behavior are consistent.
- Fixed `ui/model_package_selector_dialog.py` by removing a stray empty `for` loop artifact, importing and using `PACKAGE_TIERS` to compute `sorted_package_ids`, and iterating `sorted_package_ids` for the manual package checkbox order so UI ordering is deterministic and tier-aware.
- Kept existing preset selection and accept/skip/local-only flows intact while ensuring code compiles and the first-run dialog logic is correct.

### Testing

- Ran `python -m compileall -f -q ui/model_package_selector_dialog.py utils/model_packages.py` and `python -m compileall -f -q .` and both completed successfully.
- Performed a runtime smoke import test with `python - <<'PY' ...` that imported `utils.model_packages` and exercised `MODEL_PACKAGES`, `PACKAGE_LABELS`, `MODEL_PACKAGE_PRESETS`, `DEFAULT_MODEL_PACKAGE_PRESET_ID`, and `get_package_ids_for_preset`, which succeeded.
- Attempted a Qt dialog runtime smoke test with `QT_QPA_PLATFORM=offscreen` but it failed in this environment due to a missing system library (`libGL.so.1`), so the dialog could not be exercised here.
- Verified local branch list showed no extra branches to remove (only the working branch was present).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f0ac744a44832ca30c321e9d539da3)